### PR TITLE
Added extra validation for payloads when decoding schemas #17

### DIFF
--- a/requests/validate_request.go
+++ b/requests/validate_request.go
@@ -4,21 +4,21 @@
 package requests
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"github.com/pb33f/libopenapi-validator/errors"
-	"github.com/pb33f/libopenapi-validator/helpers"
-	"github.com/pb33f/libopenapi-validator/schema_validation"
-	"github.com/pb33f/libopenapi/datamodel/high/base"
-	"github.com/santhosh-tekuri/jsonschema/v5"
-	"gopkg.in/yaml.v3"
-	"io"
-	"net/http"
-	"reflect"
-	"regexp"
-	"strconv"
-	"strings"
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "github.com/pb33f/libopenapi-validator/errors"
+    "github.com/pb33f/libopenapi-validator/helpers"
+    "github.com/pb33f/libopenapi-validator/schema_validation"
+    "github.com/pb33f/libopenapi/datamodel/high/base"
+    "github.com/santhosh-tekuri/jsonschema/v5"
+    "gopkg.in/yaml.v3"
+    "io"
+    "net/http"
+    "reflect"
+    "regexp"
+    "strconv"
+    "strings"
 )
 
 var instanceLocationRegex = regexp.MustCompile(`^/(\d+)`)
@@ -26,120 +26,146 @@ var instanceLocationRegex = regexp.MustCompile(`^/(\d+)`)
 // ValidateRequestSchema will validate an http.Request pointer against a schema.
 // If validation fails, it will return a list of validation errors as the second return value.
 func ValidateRequestSchema(
-	request *http.Request,
-	schema *base.Schema,
-	renderedSchema,
-	jsonSchema []byte) (bool, []*errors.ValidationError) {
+    request *http.Request,
+    schema *base.Schema,
+    renderedSchema,
+    jsonSchema []byte) (bool, []*errors.ValidationError) {
 
-	var validationErrors []*errors.ValidationError
+    var validationErrors []*errors.ValidationError
 
-	requestBody, _ := io.ReadAll(request.Body)
+    requestBody, _ := io.ReadAll(request.Body)
 
-	// close the request body, so it can be re-read later by another player in the chain
-	_ = request.Body.Close()
-	request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
+    // close the request body, so it can be re-read later by another player in the chain
+    _ = request.Body.Close()
+    request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
 
-	var decodedObj interface{}
-	_ = json.Unmarshal(requestBody, &decodedObj)
+    var decodedObj interface{}
 
-	// no request body? failed to decode anything? nothing to do here.
-	if requestBody == nil || decodedObj == nil {
-		return true, nil
-	}
+    if len(requestBody) > 0 {
+        err := json.Unmarshal(requestBody, &decodedObj)
 
-	compiler := jsonschema.NewCompiler()
-	_ = compiler.AddResource("requestBody.json", strings.NewReader(string(jsonSchema)))
-	jsch, _ := compiler.Compile("requestBody.json")
+        if err != nil {
+            // cannot decode the request body, so it's not valid
+            violation := &errors.SchemaValidationFailure{
+                Reason:          err.Error(),
+                Location:        "unavailable",
+                ReferenceSchema: string(renderedSchema),
+                ReferenceObject: string(requestBody),
+            }
+            validationErrors = append(validationErrors, &errors.ValidationError{
+                ValidationType:    helpers.RequestBodyValidation,
+                ValidationSubType: helpers.Schema,
+                Message: fmt.Sprintf("%s request body for '%s' failed to validate schema",
+                    request.Method, request.URL.Path),
+                Reason:                 fmt.Sprintf("The request body cannot be decoded: %s", err.Error()),
+                SpecLine:               1,
+                SpecCol:                0,
+                SchemaValidationErrors: []*errors.SchemaValidationFailure{violation},
+                HowToFix:               errors.HowToFixInvalidSchema,
+                Context:                string(renderedSchema), // attach the rendered schema to the error
+            })
+            return false, validationErrors
+        }
+    }
 
-	// 4. validate the object against the schema
-	scErrs := jsch.Validate(decodedObj)
-	if scErrs != nil {
-		jk := scErrs.(*jsonschema.ValidationError)
+    // no request body? failed to decode anything? nothing to do here.
+    if requestBody == nil || decodedObj == nil {
+        return true, nil
+    }
 
-		// flatten the validationErrors
-		schFlatErrs := jk.BasicOutput().Errors
-		var schemaValidationErrors []*errors.SchemaValidationFailure
-		for q := range schFlatErrs {
-			er := schFlatErrs[q]
-			if er.KeywordLocation == "" || strings.HasPrefix(er.Error, "doesn't validate with") {
-				continue // ignore this error, it's useless tbh, utter noise.
-			}
-			if er.Error != "" {
+    compiler := jsonschema.NewCompiler()
+    _ = compiler.AddResource("requestBody.json", strings.NewReader(string(jsonSchema)))
+    jsch, _ := compiler.Compile("requestBody.json")
 
-				// re-encode the schema.
-				var renderedNode yaml.Node
-				_ = yaml.Unmarshal(renderedSchema, &renderedNode)
+    // 4. validate the object against the schema
+    scErrs := jsch.Validate(decodedObj)
+    if scErrs != nil {
+        jk := scErrs.(*jsonschema.ValidationError)
 
-				// locate the violated property in the schema
-				located := schema_validation.LocateSchemaPropertyNodeByJSONPath(renderedNode.Content[0], er.KeywordLocation)
+        // flatten the validationErrors
+        schFlatErrs := jk.BasicOutput().Errors
+        var schemaValidationErrors []*errors.SchemaValidationFailure
+        for q := range schFlatErrs {
+            er := schFlatErrs[q]
+            if er.KeywordLocation == "" || strings.HasPrefix(er.Error, "doesn't validate with") {
+                continue // ignore this error, it's useless tbh, utter noise.
+            }
+            if er.Error != "" {
 
-				// extract the element specified by the instance
-				val := instanceLocationRegex.FindStringSubmatch(er.InstanceLocation)
-				var referenceObject string
+                // re-encode the schema.
+                var renderedNode yaml.Node
+                _ = yaml.Unmarshal(renderedSchema, &renderedNode)
 
-				if len(val) > 0 {
-					referenceIndex, _ := strconv.Atoi(val[1])
-					if reflect.ValueOf(decodedObj).Type().Kind() == reflect.Slice {
-						found := decodedObj.([]any)[referenceIndex]
-						recoded, _ := json.MarshalIndent(found, "", "  ")
-						referenceObject = string(recoded)
-					}
-				}
-				if referenceObject == "" {
-					referenceObject = string(requestBody)
-				}
+                // locate the violated property in the schema
+                located := schema_validation.LocateSchemaPropertyNodeByJSONPath(renderedNode.Content[0], er.KeywordLocation)
 
-				violation := &errors.SchemaValidationFailure{
-					Reason:          er.Error,
-					Location:        er.KeywordLocation,
-					ReferenceSchema: string(renderedSchema),
-					ReferenceObject: referenceObject,
-					OriginalError:   jk,
-				}
-				// if we have a location within the schema, add it to the error
-				if located != nil {
+                // extract the element specified by the instance
+                val := instanceLocationRegex.FindStringSubmatch(er.InstanceLocation)
+                var referenceObject string
 
-					line := located.Line
-					// if the located node is a map or an array, then the actual human interpretable
-					// line on which the violation occurred is the line of the key, not the value.
-					if located.Kind == yaml.MappingNode || located.Kind == yaml.SequenceNode {
-						if line > 0 {
-							line--
-						}
-					}
+                if len(val) > 0 {
+                    referenceIndex, _ := strconv.Atoi(val[1])
+                    if reflect.ValueOf(decodedObj).Type().Kind() == reflect.Slice {
+                        found := decodedObj.([]any)[referenceIndex]
+                        recoded, _ := json.MarshalIndent(found, "", "  ")
+                        referenceObject = string(recoded)
+                    }
+                }
+                if referenceObject == "" {
+                    referenceObject = string(requestBody)
+                }
 
-					// location of the violation within the rendered schema.
-					violation.Line = line
-					violation.Column = located.Column
-				}
-				schemaValidationErrors = append(schemaValidationErrors, violation)
-			}
-		}
+                violation := &errors.SchemaValidationFailure{
+                    Reason:          er.Error,
+                    Location:        er.KeywordLocation,
+                    ReferenceSchema: string(renderedSchema),
+                    ReferenceObject: referenceObject,
+                    OriginalError:   jk,
+                }
+                // if we have a location within the schema, add it to the error
+                if located != nil {
 
-		line := 1
-		col := 0
-		if schema.GoLow().Type.KeyNode != nil {
-			line = schema.GoLow().Type.KeyNode.Line
-			col = schema.GoLow().Type.KeyNode.Column
-		}
+                    line := located.Line
+                    // if the located node is a map or an array, then the actual human interpretable
+                    // line on which the violation occurred is the line of the key, not the value.
+                    if located.Kind == yaml.MappingNode || located.Kind == yaml.SequenceNode {
+                        if line > 0 {
+                            line--
+                        }
+                    }
 
-		// add the error to the list
-		validationErrors = append(validationErrors, &errors.ValidationError{
-			ValidationType:    helpers.RequestBodyValidation,
-			ValidationSubType: helpers.Schema,
-			Message: fmt.Sprintf("%s request body for '%s' failed to validate schema",
-				request.Method, request.URL.Path),
-			Reason: "The request body is defined as an object. " +
-				"However, it does not meet the schema requirements of the specification",
-			SpecLine:               line,
-			SpecCol:                col,
-			SchemaValidationErrors: schemaValidationErrors,
-			HowToFix:               errors.HowToFixInvalidSchema,
-			Context:                string(renderedSchema), // attach the rendered schema to the error
-		})
-	}
-	if len(validationErrors) > 0 {
-		return false, validationErrors
-	}
-	return true, nil
+                    // location of the violation within the rendered schema.
+                    violation.Line = line
+                    violation.Column = located.Column
+                }
+                schemaValidationErrors = append(schemaValidationErrors, violation)
+            }
+        }
+
+        line := 1
+        col := 0
+        if schema.GoLow().Type.KeyNode != nil {
+            line = schema.GoLow().Type.KeyNode.Line
+            col = schema.GoLow().Type.KeyNode.Column
+        }
+
+        // add the error to the list
+        validationErrors = append(validationErrors, &errors.ValidationError{
+            ValidationType:    helpers.RequestBodyValidation,
+            ValidationSubType: helpers.Schema,
+            Message: fmt.Sprintf("%s request body for '%s' failed to validate schema",
+                request.Method, request.URL.Path),
+            Reason: "The request body is defined as an object. " +
+                "However, it does not meet the schema requirements of the specification",
+            SpecLine:               line,
+            SpecCol:                col,
+            SchemaValidationErrors: schemaValidationErrors,
+            HowToFix:               errors.HowToFixInvalidSchema,
+            Context:                string(renderedSchema), // attach the rendered schema to the error
+        })
+    }
+    if len(validationErrors) > 0 {
+        return false, validationErrors
+    }
+    return true, nil
 }

--- a/schema_validation/validate_schema_test.go
+++ b/schema_validation/validate_schema_test.go
@@ -4,16 +4,16 @@
 package schema_validation
 
 import (
-    "encoding/json"
-    "github.com/pb33f/libopenapi"
-    "github.com/stretchr/testify/assert"
-    "gopkg.in/yaml.v3"
-    "testing"
+	"encoding/json"
+	"github.com/pb33f/libopenapi"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+	"testing"
 )
 
 func TestLocateSchemaPropertyNodeByJSONPath(t *testing.T) {
 
-    spec := `openapi: 3.1.0
+	spec := `openapi: 3.1.0
 paths:
   /burgers/createBurger:
     post:
@@ -30,23 +30,23 @@ paths:
                 vegetarian:
                   type: boolean`
 
-    var node yaml.Node
-    _ = yaml.Unmarshal([]byte(spec), &node)
+	var node yaml.Node
+	_ = yaml.Unmarshal([]byte(spec), &node)
 
-    foundNode := LocateSchemaPropertyNodeByJSONPath(node.Content[0],
-        "/paths/~1burgers~1createBurger/post/requestBody/content/application~1json/schema/properties/vegetarian")
+	foundNode := LocateSchemaPropertyNodeByJSONPath(node.Content[0],
+		"/paths/~1burgers~1createBurger/post/requestBody/content/application~1json/schema/properties/vegetarian")
 
-    assert.Equal(t, "boolean", foundNode.Content[1].Value)
+	assert.Equal(t, "boolean", foundNode.Content[1].Value)
 
-    foundNode = LocateSchemaPropertyNodeByJSONPath(node.Content[0],
-        "/i/do/not/exist")
+	foundNode = LocateSchemaPropertyNodeByJSONPath(node.Content[0],
+		"/i/do/not/exist")
 
-    assert.Nil(t, foundNode)
+	assert.Nil(t, foundNode)
 
 }
 
 func TestValidateSchema_SimpleValid_String(t *testing.T) {
-    spec := `openapi: 3.1.0
+	spec := `openapi: 3.1.0
 paths:
   /burgers/createBurger:
     post:
@@ -63,32 +63,32 @@ paths:
                 vegetarian:
                   type: boolean`
 
-    doc, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := libopenapi.NewDocument([]byte(spec))
 
-    m, _ := doc.BuildV3Model()
+	m, _ := doc.BuildV3Model()
 
-    body := map[string]interface{}{
-        "name":       "Big Mac",
-        "patties":    2,
-        "vegetarian": true,
-    }
+	body := map[string]interface{}{
+		"name":       "Big Mac",
+		"patties":    2,
+		"vegetarian": true,
+	}
 
-    bodyBytes, _ := json.Marshal(body)
-    sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	bodyBytes, _ := json.Marshal(body)
+	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // create a schema validator
-    v := NewSchemaValidator()
+	// create a schema validator
+	v := NewSchemaValidator()
 
-    // validate!
-    valid, errors := v.ValidateSchemaString(sch.Schema(), string(bodyBytes))
+	// validate!
+	valid, errors := v.ValidateSchemaString(sch.Schema(), string(bodyBytes))
 
-    assert.True(t, valid)
-    assert.Len(t, errors, 0)
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
 
 }
 
 func TestValidateSchema_SimpleValid(t *testing.T) {
-    spec := `openapi: 3.1.0
+	spec := `openapi: 3.1.0
 paths:
   /burgers/createBurger:
     post:
@@ -105,32 +105,32 @@ paths:
                 vegetarian:
                   type: boolean`
 
-    doc, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := libopenapi.NewDocument([]byte(spec))
 
-    m, _ := doc.BuildV3Model()
+	m, _ := doc.BuildV3Model()
 
-    body := map[string]interface{}{
-        "name":       "Big Mac",
-        "patties":    2,
-        "vegetarian": true,
-    }
+	body := map[string]interface{}{
+		"name":       "Big Mac",
+		"patties":    2,
+		"vegetarian": true,
+	}
 
-    // create a schema validator
-    v := NewSchemaValidator()
+	// create a schema validator
+	v := NewSchemaValidator()
 
-    bodyBytes, _ := json.Marshal(body)
-    sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	bodyBytes, _ := json.Marshal(body)
+	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // validate!
-    valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
+	// validate!
+	valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
 
-    assert.True(t, valid)
-    assert.Len(t, errors, 0)
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
 
 }
 
 func TestValidateSchema_SimpleInValid(t *testing.T) {
-    spec := `openapi: 3.1.0
+	spec := `openapi: 3.1.0
 paths:
   /burgers/createBurger:
     post:
@@ -147,32 +147,32 @@ paths:
                 vegetarian:
                   type: boolean`
 
-    doc, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := libopenapi.NewDocument([]byte(spec))
 
-    m, _ := doc.BuildV3Model()
+	m, _ := doc.BuildV3Model()
 
-    body := map[string]interface{}{
-        "name":       "Big Mac",
-        "patties":    "I am not a number", // will fail
-        "vegetarian": 23,                  // will fail
-    }
+	body := map[string]interface{}{
+		"name":       "Big Mac",
+		"patties":    "I am not a number", // will fail
+		"vegetarian": 23,                  // will fail
+	}
 
-    // create a schema validator
-    v := NewSchemaValidator()
+	// create a schema validator
+	v := NewSchemaValidator()
 
-    bodyBytes, _ := json.Marshal(body)
-    sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	bodyBytes, _ := json.Marshal(body)
+	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // validate!
-    valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
+	// validate!
+	valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
 
-    assert.False(t, valid)
-    assert.Len(t, errors, 1)
-    assert.Len(t, errors[0].SchemaValidationErrors, 2)
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Len(t, errors[0].SchemaValidationErrors, 2)
 }
 
 func TestValidateSchema_InvalidJSONType(t *testing.T) {
-    spec := `openapi: 3.1.0
+	spec := `openapi: 3.1.0
 paths:
   /burgers/createBurger:
     post:
@@ -189,29 +189,29 @@ paths:
                 vegetarian:
                   type: boolean`
 
-    doc, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := libopenapi.NewDocument([]byte(spec))
 
-    m, _ := doc.BuildV3Model()
+	m, _ := doc.BuildV3Model()
 
-    body := struct{ name string }{"hello world"}
+	body := struct{ name string }{"hello world"}
 
-    // create a schema validator
-    v := NewSchemaValidator()
+	// create a schema validator
+	v := NewSchemaValidator()
 
-    //bodyBytes, _ := json.Marshal(body)
-    sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	//bodyBytes, _ := json.Marshal(body)
+	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // validate!
-    valid, errors := v.ValidateSchemaObject(sch.Schema(), body)
+	// validate!
+	valid, errors := v.ValidateSchemaObject(sch.Schema(), body)
 
-    assert.False(t, valid)
-    assert.Len(t, errors, 1)
-    assert.Len(t, errors[0].SchemaValidationErrors, 1)
-    assert.Equal(t, "jsonschema: invalid jsonType: struct { name string }", errors[0].SchemaValidationErrors[0].Reason)
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Len(t, errors[0].SchemaValidationErrors, 1)
+	assert.Equal(t, "jsonschema: invalid jsonType: struct { name string }", errors[0].SchemaValidationErrors[0].Reason)
 }
 
 func TestValidateSchema_ReffyComplex_Valid(t *testing.T) {
-    spec := `openapi: 3.1.0
+	spec := `openapi: 3.1.0
 components:
   schemas:
     Death:
@@ -263,57 +263,57 @@ paths:
             schema:
               $ref: '#/components/schemas/One'`
 
-    doc, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := libopenapi.NewDocument([]byte(spec))
 
-    m, _ := doc.BuildV3Model()
+	m, _ := doc.BuildV3Model()
 
-    cakePlease := map[string]interface{}{
-        "two": map[string]interface{}{
-            "three": map[string]interface{}{
-                "four": map[string]interface{}{
-                    "cakeOrDeath": "cake please",
-                },
-            },
-        },
-    }
+	cakePlease := map[string]interface{}{
+		"two": map[string]interface{}{
+			"three": map[string]interface{}{
+				"four": map[string]interface{}{
+					"cakeOrDeath": "cake please",
+				},
+			},
+		},
+	}
 
-    death := map[string]interface{}{
-        "two": map[string]interface{}{
-            "three": map[string]interface{}{
-                "four": map[string]interface{}{
-                    "cakeOrDeath": "death",
-                },
-            },
-        },
-    }
+	death := map[string]interface{}{
+		"two": map[string]interface{}{
+			"three": map[string]interface{}{
+				"four": map[string]interface{}{
+					"cakeOrDeath": "death",
+				},
+			},
+		},
+	}
 
-    // cake? (https://www.youtube.com/watch?v=PVH0gZO5lq0)
-    bodyBytes, _ := json.Marshal(cakePlease)
-    sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	// cake? (https://www.youtube.com/watch?v=PVH0gZO5lq0)
+	bodyBytes, _ := json.Marshal(cakePlease)
+	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // create a schema validator
-    v := NewSchemaValidator()
+	// create a schema validator
+	v := NewSchemaValidator()
 
-    // validate!
-    valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
+	// validate!
+	valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
 
-    assert.True(t, valid)
-    assert.Len(t, errors, 0)
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
 
-    // or death!
-    bodyBytes, _ = json.Marshal(death)
-    sch = m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	// or death!
+	bodyBytes, _ = json.Marshal(death)
+	sch = m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // validate!
-    valid, errors = v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
+	// validate!
+	valid, errors = v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
 
-    assert.True(t, valid)
-    assert.Len(t, errors, 0)
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
 
 }
 
 func TestValidateSchema_ReffyComplex_Invalid(t *testing.T) {
-    spec := `openapi: 3.1.0
+	spec := `openapi: 3.1.0
 components:
   schemas:
     Death:
@@ -365,83 +365,83 @@ paths:
             schema:
               $ref: '#/components/schemas/One'`
 
-    doc, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := libopenapi.NewDocument([]byte(spec))
 
-    m, _ := doc.BuildV3Model()
+	m, _ := doc.BuildV3Model()
 
-    cakePlease := map[string]interface{}{
-        "two": map[string]interface{}{
-            "three": map[string]interface{}{
-                "four": map[string]interface{}{
-                    "cakeOrDeath": "no more cake? so the choice is 'or death?'",
-                },
-            },
-        },
-    }
+	cakePlease := map[string]interface{}{
+		"two": map[string]interface{}{
+			"three": map[string]interface{}{
+				"four": map[string]interface{}{
+					"cakeOrDeath": "no more cake? so the choice is 'or death?'",
+				},
+			},
+		},
+	}
 
-    death := map[string]interface{}{
-        "two": map[string]interface{}{
-            "three": map[string]interface{}{
-                "four": map[string]interface{}{
-                    "cakeOrDeath": "i'll have the chicken",
-                },
-            },
-        },
-    }
+	death := map[string]interface{}{
+		"two": map[string]interface{}{
+			"three": map[string]interface{}{
+				"four": map[string]interface{}{
+					"cakeOrDeath": "i'll have the chicken",
+				},
+			},
+		},
+	}
 
-    // cake? (https://www.youtube.com/watch?v=PVH0gZO5lq0)
-    bodyBytes, _ := json.Marshal(cakePlease)
-    sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	// cake? (https://www.youtube.com/watch?v=PVH0gZO5lq0)
+	bodyBytes, _ := json.Marshal(cakePlease)
+	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // create a schema validator
-    v := NewSchemaValidator()
+	// create a schema validator
+	v := NewSchemaValidator()
 
-    // validate!
-    valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
+	// validate!
+	valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
 
-    assert.False(t, valid)
-    assert.Len(t, errors, 1)
-    assert.Len(t, errors[0].SchemaValidationErrors, 3)
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Len(t, errors[0].SchemaValidationErrors, 3)
 
-    valid, errors = v.ValidateSchemaObject(sch.Schema(), cakePlease)
+	valid, errors = v.ValidateSchemaObject(sch.Schema(), cakePlease)
 
-    assert.False(t, valid)
-    assert.Len(t, errors, 1)
-    assert.Len(t, errors[0].SchemaValidationErrors, 3)
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Len(t, errors[0].SchemaValidationErrors, 3)
 
-    // or death!
-    bodyBytes, _ = json.Marshal(death)
-    sch = m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	// or death!
+	bodyBytes, _ = json.Marshal(death)
+	sch = m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // validate!
-    valid, errors = v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
+	// validate!
+	valid, errors = v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
 
-    assert.False(t, valid)
-    assert.Len(t, errors, 1)
-    assert.Len(t, errors[0].SchemaValidationErrors, 3)
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Len(t, errors[0].SchemaValidationErrors, 3)
 
-    valid, errors = v.ValidateSchemaObject(sch.Schema(), death)
+	valid, errors = v.ValidateSchemaObject(sch.Schema(), death)
 
-    assert.False(t, valid)
-    assert.Len(t, errors, 1)
-    assert.Len(t, errors[0].SchemaValidationErrors, 3)
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Len(t, errors[0].SchemaValidationErrors, 3)
 
 }
 
 func TestValidateSchema_EmptySchema(t *testing.T) {
 
-    // create a schema validator
-    v := NewSchemaValidator()
+	// create a schema validator
+	v := NewSchemaValidator()
 
-    // validate!
-    valid, errors := v.ValidateSchemaObject(nil, nil)
+	// validate!
+	valid, errors := v.ValidateSchemaObject(nil, nil)
 
-    assert.False(t, valid)
-    assert.Len(t, errors, 0)
+	assert.False(t, valid)
+	assert.Len(t, errors, 0)
 }
 
 func TestValidateSchema_SimpleInvalid_Multiple(t *testing.T) {
-    spec := `openapi: 3.1.0
+	spec := `openapi: 3.1.0
 paths:
   /burgers/createBurger:
     post:
@@ -462,37 +462,75 @@ paths:
                   vegetarian:
                     type: boolean`
 
-    doc, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := libopenapi.NewDocument([]byte(spec))
 
-    m, _ := doc.BuildV3Model()
+	m, _ := doc.BuildV3Model()
 
-    var items []map[string]interface{}
-    items = append(items, map[string]interface{}{
-        "patties":    1,
-        "vegetarian": true,
-    })
-    items = append(items, map[string]interface{}{
-        "name":       "Quarter Pounder",
-        "patties":    true,
-        "vegetarian": false,
-    })
-    items = append(items, map[string]interface{}{
-        "name":       "Big Mac",
-        "patties":    2,
-        "vegetarian": false,
-    })
+	var items []map[string]interface{}
+	items = append(items, map[string]interface{}{
+		"patties":    1,
+		"vegetarian": true,
+	})
+	items = append(items, map[string]interface{}{
+		"name":       "Quarter Pounder",
+		"patties":    true,
+		"vegetarian": false,
+	})
+	items = append(items, map[string]interface{}{
+		"name":       "Big Mac",
+		"patties":    2,
+		"vegetarian": false,
+	})
 
-    bodyBytes, _ := json.Marshal(items)
+	bodyBytes, _ := json.Marshal(items)
 
-    // create a schema validator
-    v := NewSchemaValidator()
+	// create a schema validator
+	v := NewSchemaValidator()
 
-    sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
 
-    // validate!
-    valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
+	// validate!
+	valid, errors := v.ValidateSchemaBytes(sch.Schema(), bodyBytes)
 
-    assert.False(t, valid)
-    assert.Len(t, errors, 1)
-    assert.Len(t, errors[0].SchemaValidationErrors, 2)
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Len(t, errors[0].SchemaValidationErrors, 2)
+}
+
+func TestValidateSchema_BadJSON(t *testing.T) {
+	spec := `openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                patties:
+                  type: integer
+                vegetarian:
+                  type: boolean`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+
+	m, _ := doc.BuildV3Model()
+
+	bodyBytes := []byte("{\"bad\": \"json\",}")
+	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+
+	// create a schema validator
+	v := NewSchemaValidator()
+
+	// validate!
+	valid, errors := v.ValidateSchemaString(sch.Schema(), string(bodyBytes))
+
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Equal(t, "schema does not pass validation", errors[0].Message)
+	assert.Equal(t, "invalid character '}' looking for beginning of object key string", errors[0].SchemaValidationErrors[0].Reason)
+
 }


### PR DESCRIPTION
Schema payloads may be invalid and cannot be decoded. This was being skipped over before. The validator can no-longer be tricked by an invalid payload.

Fixes #17 