### PR TITLE
Fixed panic when type on schema is empty. #22

### DIFF
--- a/parameters/query_parameters.go
+++ b/parameters/query_parameters.go
@@ -217,7 +217,7 @@ doneLooking:
 				if params[p].Schema != nil {
 					sch := params[p].Schema.Schema()
 
-					if sch.Type[0] == helpers.Object && params[p].IsDefaultFormEncoding() {
+					if len(sch.Type) > 0 && sch.Type[0] == helpers.Object && params[p].IsDefaultFormEncoding() {
 						// if the param is an object, and we're using default encoding, then we need to
 						// validate the schema.
 						decoded := helpers.ConstructParamMapFromQueryParamInput(queryParams)


### PR DESCRIPTION
A panic was being thrown when a schema is missing a type and checking for a query param. All schemas should always have a type, assumption however is the mother of all f**kups.