### PR TITLE
refactor(ValidateRequestBody): reduce cyclomatic complexity and indent

### DIFF
--- a/requests/validate_body.go
+++ b/requests/validate_body.go
@@ -30,15 +30,13 @@ func (v *requestBodyValidator) ValidateRequestBody(request *http.Request) (bool,
 
 	operation := helpers.ExtractOperation(request, pathItem)
 	if operation.RequestBody == nil {
-		// TODO: check if requestBody is marked as required
 		return true, nil
 	}
 
 	// extract the content type from the request
 	contentType := request.Header.Get(helpers.ContentTypeHeader)
 	if contentType == "" {
-		//TODO: should this ever return errors?
-		return true, nil
+		return false, []*errors.ValidationError{errors.RequestContentTypeNotFound(operation, request)}
 	}
 
 	// extract the media type from the content type header.

--- a/requests/validate_body.go
+++ b/requests/validate_body.go
@@ -4,94 +4,89 @@
 package requests
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/pb33f/libopenapi-validator/errors"
 	"github.com/pb33f/libopenapi-validator/helpers"
 	"github.com/pb33f/libopenapi-validator/paths"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/utils"
-	"net/http"
-	"strings"
 )
 
 func (v *requestBodyValidator) ValidateRequestBody(request *http.Request) (bool, []*errors.ValidationError) {
 
 	// find path
-	var pathItem *v3.PathItem
-	var errs []*errors.ValidationError
+	var pathItem *v3.PathItem = v.pathItem
 	if v.pathItem == nil {
-		pathItem, errs, _ = paths.FindPath(request, v.document)
-		if pathItem == nil || errs != nil {
-			v.errors = errs
-			return false, errs
+		var validationErrors []*errors.ValidationError
+		pathItem, validationErrors, _ = paths.FindPath(request, v.document)
+		if pathItem == nil || validationErrors != nil {
+			v.errors = validationErrors
+			return false, validationErrors
 		}
-	} else {
-		pathItem = v.pathItem
 	}
 
-	var validationErrors []*errors.ValidationError
 	operation := helpers.ExtractOperation(request, pathItem)
+	if operation.RequestBody == nil {
+		// TODO: check if requestBody is marked as required
+		return true, nil
+	}
 
-	var contentType string
 	// extract the content type from the request
+	contentType := request.Header.Get(helpers.ContentTypeHeader)
+	if contentType == "" {
+		//TODO: should this ever return errors?
+		return true, nil
+	}
 
-	if contentType = request.Header.Get(helpers.ContentTypeHeader); contentType != "" {
+	// extract the media type from the content type header.
+	ct, _, _ := helpers.ExtractContentType(contentType)
+	mediaType, ok := operation.RequestBody.Content[ct]
+	if !ok {
+		return false, []*errors.ValidationError{errors.RequestContentTypeNotFound(operation, request)}
+	}
 
-		// extract the media type from the content type header.
-		ct, _, _ := helpers.ExtractContentType(contentType)
-		if operation.RequestBody != nil {
-			if mediaType, ok := operation.RequestBody.Content[ct]; ok {
+	// we currently only support JSON validation for request bodies
+	// this will capture *everything* that contains some form of 'json' in the content type
+	if !strings.Contains(strings.ToLower(contentType), helpers.JSONType) {
+		return true, nil
+	}
 
-				// we currently only support JSON validation for request bodies
-				// this will capture *everything* that contains some form of 'json' in the content type
-				if strings.Contains(strings.ToLower(contentType), helpers.JSONType) {
+	// Nothing to validate
+	if mediaType.Schema == nil {
+		return true, nil
+	}
 
-					// extract schema from media type
-					if mediaType.Schema != nil {
+	// extract schema from media type
+	var schema *base.Schema
+	var renderedInline, renderedJSON []byte
 
-						var schema *base.Schema
-						var renderedInline, renderedJSON []byte
+	// have we seen this schema before? let's hash it and check the cache.
+	hash := mediaType.GoLow().Schema.Value.Hash()
 
-						// have we seen this schema before? let's hash it and check the cache.
-						hash := mediaType.GoLow().Schema.Value.Hash()
+	// perform work only once and cache the result in the validator.
+	if cacheHit, ch := v.schemaCache[hash]; ch {
+		// got a hit, use cached values
+		schema = cacheHit.schema
+		renderedInline = cacheHit.renderedInline
+		renderedJSON = cacheHit.renderedJSON
 
-						// perform work only once and cache the result in the validator.
-						if cacheHit, ch := v.schemaCache[hash]; ch {
+	} else {
 
-							// got a hit, use cached values
-							schema = cacheHit.schema
-							renderedInline = cacheHit.renderedInline
-							renderedJSON = cacheHit.renderedJSON
-
-						} else {
-
-							// render the schema inline and perform the intensive work of rendering and converting
-							// this is only performed once per schema and cached in the validator.
-							schema = mediaType.Schema.Schema()
-							renderedInline, _ = schema.RenderInline()
-							renderedJSON, _ = utils.ConvertYAMLtoJSON(renderedInline)
-							v.schemaCache[hash] = &schemaCache{
-								schema:         schema,
-								renderedInline: renderedInline,
-								renderedJSON:   renderedJSON,
-							}
-						}
-
-						//render the schema, to be used for validation
-						valid, vErrs := ValidateRequestSchema(request, schema, renderedInline, renderedJSON)
-						if !valid {
-							validationErrors = append(validationErrors, vErrs...)
-						}
-					}
-				}
-			} else {
-				// content type not found in the contract
-				validationErrors = append(validationErrors, errors.RequestContentTypeNotFound(operation, request))
-			}
+		// render the schema inline and perform the intensive work of rendering and converting
+		// this is only performed once per schema and cached in the validator.
+		schema = mediaType.Schema.Schema()
+		renderedInline, _ = schema.RenderInline()
+		renderedJSON, _ = utils.ConvertYAMLtoJSON(renderedInline)
+		v.schemaCache[hash] = &schemaCache{
+			schema:         schema,
+			renderedInline: renderedInline,
+			renderedJSON:   renderedJSON,
 		}
 	}
-	if len(validationErrors) > 0 {
-		return false, validationErrors
-	}
-	return true, nil
+
+	//render the schema, to be used for validation
+	return ValidateRequestSchema(request, schema, renderedInline, renderedJSON)
 }


### PR DESCRIPTION
Use the early-out pattern to reduce code complexity.
None of the existing logic should have changed, and all tests pass.

@daveshanley Can you fact check me at line 40? At this point, are there any errors that could occur here?
