### PR TITLE
Had to rollback some changes. v0.0.22

### DIFF
--- a/schema_validation/validate_schema.go
+++ b/schema_validation/validate_schema.go
@@ -85,11 +85,13 @@ func validateSchema(schema *base.Schema, payload []byte, decodedObject interface
 	// render the schema, to be used for validation, stop this from running concurrently, mutations are made to state
 	// and, it will cause async issues.
 	renderLock.Lock()
-	version := float32(0.0)
+
+	//version := float32(0.0)
 	if schemaIndex != nil {
-		version = schemaIndex.GetConfig().SpecInfo.VersionNumeric
-		renderedSchema, _ = schema.RenderInline()
+		//version = schemaIndex.GetConfig().SpecInfo.VersionNumeric
+
 	}
+	renderedSchema, _ = schema.RenderInline()
 	renderLock.Unlock()
 
 	jsonSchema, _ := utils.ConvertYAMLtoJSON(renderedSchema)
@@ -121,11 +123,15 @@ func validateSchema(schema *base.Schema, payload []byte, decodedObject interface
 
 	}
 	compiler := jsonschema.NewCompiler()
-	if version >= 3.1 {
-		compiler.Draft = jsonschema.Draft2020
-	} else {
-		compiler.Draft = jsonschema.Draft4
-	}
+
+	// setting this will break existing vacuum OWASP rules, that assume a 2020 validator for if/else/then schema
+	// validations.
+	//switch version {
+	//case 3.0, 2.0:
+	//	compiler.Draft = jsonschema.Draft4
+	//default:
+	//	compiler.Draft = jsonschema.Draft2020
+	//}
 
 	_ = compiler.AddResource("schema.json", strings.NewReader(string(jsonSchema)))
 	jsch, err := compiler.Compile("schema.json")

--- a/schema_validation/validate_schema_test.go
+++ b/schema_validation/validate_schema_test.go
@@ -535,43 +535,43 @@ paths:
 
 }
 
-// https://github.com/pb33f/libopenapi-validator/issues/26
-func TestValidateSchema_v3_0_BooleanExclusiveMinimum(t *testing.T) {
-
-	spec := `openapi: 3.0.0
-paths:
-  /burgers/createBurger:
-    post:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                amount:
-                  type: number
-                  minimum: 0
-                  exclusiveMinimum: true`
-
-	doc, _ := libopenapi.NewDocument([]byte(spec))
-
-	m, _ := doc.BuildV3Model()
-
-	body := map[string]interface{}{"amount": 3}
-
-	bodyBytes, _ := json.Marshal(body)
-	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
-
-	// create a schema validator
-	v := NewSchemaValidator()
-
-	// validate!
-	valid, errors := v.ValidateSchemaString(sch.Schema(), string(bodyBytes))
-
-	assert.True(t, valid)
-	assert.Empty(t, errors)
-
-}
+//// https://github.com/pb33f/libopenapi-validator/issues/26
+//func TestValidateSchema_v3_0_BooleanExclusiveMinimum(t *testing.T) {
+//
+//	spec := `openapi: 3.0.0
+//paths:
+//  /burgers/createBurger:
+//    post:
+//      requestBody:
+//        content:
+//          application/json:
+//            schema:
+//              type: object
+//              properties:
+//                amount:
+//                  type: number
+//                  minimum: 0
+//                  exclusiveMinimum: true`
+//
+//	doc, _ := libopenapi.NewDocument([]byte(spec))
+//
+//	m, _ := doc.BuildV3Model()
+//
+//	body := map[string]interface{}{"amount": 3}
+//
+//	bodyBytes, _ := json.Marshal(body)
+//	sch := m.Model.Paths.PathItems["/burgers/createBurger"].Post.RequestBody.Content["application/json"].Schema
+//
+//	// create a schema validator
+//	v := NewSchemaValidator()
+//
+//	// validate!
+//	valid, errors := v.ValidateSchemaString(sch.Schema(), string(bodyBytes))
+//
+//	assert.True(t, valid)
+//	assert.Empty(t, errors)
+//
+//}
 
 // https://github.com/pb33f/libopenapi-validator/issues/26
 func TestValidateSchema_v3_0_NumericExclusiveMinimum(t *testing.T) {


### PR DESCRIPTION
vacuum OWASP rules depend on the validator being set in 2020 mode, vs Draft4. If we use the version to set the draft when validating inline schemas, we end up blowing up half of vacuum.

vacuum is a priority.