### PR TITLE
Added base path stripping for the request path during path parameter …

### DIFF
--- a/parameters/path_parameters.go
+++ b/parameters/path_parameters.go
@@ -33,15 +33,15 @@ func (v *paramValidator) ValidatePathParams(request *http.Request) (bool, []*err
 		foundPath = v.pathValue
 	}
 
+	// split the path into segments
+	submittedSegments := strings.Split(paths.StripRequestPath(request, v.document), helpers.Slash)
+	pathSegments := strings.Split(foundPath, helpers.Slash)
+
 	// extract params for the operation
 	var params = helpers.ExtractParamsForOperation(request, pathItem)
 	var validationErrors []*errors.ValidationError
 	for _, p := range params {
 		if p.In == helpers.Path {
-
-			// split the path into segments
-			submittedSegments := strings.Split(request.URL.Path, helpers.Slash)
-			pathSegments := strings.Split(foundPath, helpers.Slash)
 
 			// var paramTemplate string
 			for x := range pathSegments {

--- a/parameters/path_parameters_test.go
+++ b/parameters/path_parameters_test.go
@@ -1404,7 +1404,7 @@ paths:
 	assert.Equal(t, "Instead of '22334', use one of the allowed values: '1, 2, 99, 100'", errors[0].HowToFix)
 }
 
-func TestNewValidator_FillInThis(t *testing.T) {
+func TestNewValidator_ServerPathPrefixInRequestPath(t *testing.T) {
 
 	spec := `openapi: 3.1.0
 servers:

--- a/parameters/path_parameters_test.go
+++ b/parameters/path_parameters_test.go
@@ -1416,12 +1416,8 @@ paths:
       - name: burger
         in: path
         schema:
-          type: object
-          properties:
-            id:
-               type: integer
-            vegetarian:
-               type: boolean
+          type: string
+          format: uuid
     get:
       operationId: locateBurger`
 
@@ -1431,7 +1427,7 @@ paths:
 
 	v := NewParameterValidator(&m.Model)
 
-	request, _ := http.NewRequest(http.MethodGet, "https://things.com/lorem/ipsum/burgers/id,1234,vegetarian,true/locate", nil)
+	request, _ := http.NewRequest(http.MethodGet, "https://things.com/lorem/ipsum/burgers/d6d8d513-686c-466f-9f5a-1c051b6b4f3f/locate", nil)
 	valid, errors := v.ValidatePathParams(request)
 
 	assert.True(t, valid)

--- a/parameters/path_parameters_test.go
+++ b/parameters/path_parameters_test.go
@@ -1403,3 +1403,37 @@ paths:
 	assert.Equal(t, "Path parameter 'burgerId' does not match allowed values", errors[0].Message)
 	assert.Equal(t, "Instead of '22334', use one of the allowed values: '1, 2, 99, 100'", errors[0].HowToFix)
 }
+
+func TestNewValidator_FillInThis(t *testing.T) {
+
+	spec := `openapi: 3.1.0
+servers:
+  - url: https://api.pb33f.io/lorem/ipsum
+    description: Live production endpoint for general use.
+paths:
+  /burgers/{burger}/locate:
+    parameters:
+      - name: burger
+        in: path
+        schema:
+          type: object
+          properties:
+            id:
+               type: integer
+            vegetarian:
+               type: boolean
+    get:
+      operationId: locateBurger`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+
+	m, _ := doc.BuildV3Model()
+
+	v := NewParameterValidator(&m.Model)
+
+	request, _ := http.NewRequest(http.MethodGet, "https://things.com/lorem/ipsum/burgers/id,1234,vegetarian,true/locate", nil)
+	valid, errors := v.ValidatePathParams(request)
+
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
+}

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -24,7 +24,7 @@ import (
 func FindPath(request *http.Request, document *v3.Document) (*v3.PathItem, []*errors.ValidationError, string) {
 	var validationErrors []*errors.ValidationError
 
-	basePaths := getBasePaths(request, document)
+	basePaths := getBasePaths(document)
 	stripped := StripRequestPath(request, document)
 
 	reqPathSegments := strings.Split(stripped, "/")
@@ -193,7 +193,7 @@ pathFound:
 	}
 }
 
-func getBasePaths(request *http.Request, document *v3.Document) []string {
+func getBasePaths(document *v3.Document) []string {
 	// extract base path from document to check against paths.
 	var basePaths []string
 	for _, s := range document.Servers {
@@ -209,7 +209,7 @@ func getBasePaths(request *http.Request, document *v3.Document) []string {
 // StripRequestPath strips the base path from the request path, based on the server paths provided in the specification
 func StripRequestPath(request *http.Request, document *v3.Document) string {
 
-	basePaths := getBasePaths(request, document)
+	basePaths := getBasePaths(document)
 
 	// strip any base path
 	stripped := stripBaseFromPath(request.URL.Path, basePaths)


### PR DESCRIPTION
Path parameter validation did not properly strip the base path from the request path when doing parameter validation.

If the server had a non-null postfix path, then the incorrect parameter would be validated.

I added a test to exercise this scenario to ensure this shouldn't happen again.