### PR TITLE
Fixed checkPathAgainstBase modifying basePaths unintentionally.

### DIFF
--- a/paths/paths.go
+++ b/paths/paths.go
@@ -223,11 +223,11 @@ func checkPathAgainstBase(docPath, urlPath string, basePaths []string) bool {
 	if docPath == urlPath {
 		return true
 	}
-	for i := range basePaths {
-		if basePaths[i][len(basePaths[i])-1] == '/' {
-			basePaths[i] = basePaths[i][:len(basePaths[i])-1]
+	for _, basePath := range basePaths {
+		if basePath[len(basePath)-1] == '/' {
+			basePath = basePath[:len(basePath)-1]
 		}
-		merged := fmt.Sprintf("%s%s", basePaths[i], urlPath)
+		merged := fmt.Sprintf("%s%s", basePath, urlPath)
 		if docPath == merged {
 			return true
 		}

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -634,3 +634,28 @@ paths:
 	assert.Equal(t, "two", pathItem.Post.OperationId)
 
 }
+
+func TestNewValidator_FindPathMissingWithBaseURLInServer(t *testing.T) {
+
+	spec := `openapi: 3.1.0
+servers:
+  - url: 'https://things.com/'
+paths:
+  /dishy:
+    get:
+      operationId: one
+`
+
+	doc, err := libopenapi.NewDocument([]byte(spec))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, _ := doc.BuildV3Model()
+
+	request, _ := http.NewRequest(http.MethodGet, "https://things.com/not_here", nil)
+
+	_, errs, _ := FindPath(request, &m.Model)
+	assert.Len(t, errs, 1)
+	assert.Equal(t, "GET Path '/not_here' not found", errs[0].Message)
+
+}


### PR DESCRIPTION
Hi there. Thank you for GREAT pkgs!

I fixed a problem where checkPathAgainstBase was unintentionally changing the basePath.
Also added a test that was panicky before the fix.

```console
$ go test ./paths/... -run TestNewValidator_FindPathMissingWithBaseURLInServer
--- FAIL: TestNewValidator_FindPathMissingWithBaseURLInServer (0.00s)
panic: runtime error: index out of range [-1] [recovered]
        panic: runtime error: index out of range [-1]

goroutine 19 [running]:
testing.tRunner.func1.2({0x100ff8840, 0x140000181e0})
        /Users/k1low/sdk/go1.22.1/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /Users/k1low/sdk/go1.22.1/src/testing/testing.go:1634 +0x33c
panic({0x100ff8840?, 0x140000181e0?})
        /Users/k1low/sdk/go1.22.1/src/runtime/panic.go:770 +0x124
github.com/pb33f/libopenapi-validator/paths.checkPathAgainstBase({0x140001cfad1, 0x5}, {0x100e467a0, 0x8}, {0x1400002a0f0, 0x1, 0x14000010140?})
        /Users/k1low/src/github.com/pb33f/libopenapi-validator/paths/paths.go:227 +0x180
github.com/pb33f/libopenapi-validator/paths.comparePaths({0x140000782b0?, 0x1, 0x140001cfad0?}, {0x1400002a110, 0x1, 0x1}, {0x1400002a0f0, 0x1, 0x1})
        /Users/k1low/src/github.com/pb33f/libopenapi-validator/paths/paths.go:261 +0x1f0
github.com/pb33f/libopenapi-validator/paths.FindPath(0x14000000120, 0x14000394000)
        /Users/k1low/src/github.com/pb33f/libopenapi-validator/paths/paths.go:66 +0x270
github.com/pb33f/libopenapi-validator/paths.TestNewValidator_FindPathMissingWithBaseURLInServer(0x140001d0b60)
        /Users/k1low/src/github.com/pb33f/libopenapi-validator/paths/paths_test.go:657 +0xd0
testing.tRunner(0x140001d0b60, 0x101066d18)
        /Users/k1low/sdk/go1.22.1/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
        /Users/k1low/sdk/go1.22.1/src/testing/testing.go:1742 +0x318
FAIL    github.com/pb33f/libopenapi-validator/paths     0.200s
FAIL
```