### PR TITLE
Raise an error if the securityScheme to be referenced does not exist.

### DIFF
--- a/parameters/validate_security_test.go
+++ b/parameters/validate_security_test.go
@@ -291,6 +291,53 @@ components:
 	assert.Equal(t, 1, len(errors))
 }
 
+func TestParamValidator_ValidateSecurity_MissingSecuritySchemes(t *testing.T) {
+
+	spec := `openapi: 3.1.0
+paths:
+  /products:
+    post:
+      security:
+        - ApiKeyAuth:
+          - write:products
+components: {}
+`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+
+	m, _ := doc.BuildV3Model()
+
+	v := NewParameterValidator(&m.Model)
+
+	request, _ := http.NewRequest(http.MethodPost, "https://things.com/products", nil)
+	valid, errors := v.ValidateSecurity(request)
+	assert.False(t, valid)
+	assert.Equal(t, 1, len(errors))
+}
+
+func TestParamValidator_ValidateSecurity_NoComponents(t *testing.T) {
+
+	spec := `openapi: 3.1.0
+paths:
+  /products:
+    post:
+      security:
+        - ApiKeyAuth:
+          - write:products
+`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+
+	m, _ := doc.BuildV3Model()
+
+	v := NewParameterValidator(&m.Model)
+
+	request, _ := http.NewRequest(http.MethodPost, "https://things.com/products", nil)
+	valid, errors := v.ValidateSecurity(request)
+	assert.False(t, valid)
+	assert.Equal(t, 1, len(errors))
+}
+
 func TestParamValidator_ValidateSecurity_PresetPath(t *testing.T) {
 
 	spec := `openapi: 3.1.0


### PR DESCRIPTION
Hi there.

I fixed a problem when the securityScheme to be referenced does not exist.

```
--- FAIL: TestParamValidator_ValidateSecurity_MissingSecuritySchemes (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10242c5d8]

goroutine 733 [running]:
testing.tRunner.func1.2({0x1025a04a0, 0x1029ea420})
        /Users/k1low/sdk/go1.22.1/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /Users/k1low/sdk/go1.22.1/src/testing/testing.go:1634 +0x33c
panic({0x1025a04a0?, 0x1029ea420?})
        /Users/k1low/sdk/go1.22.1/src/runtime/panic.go:770 +0x124
github.com/pb33f/libopenapi-validator/parameters.(*paramValidator).ValidateSecurity(0x14000377f20, 0x140003b6ea0)
        /Users/k1low/src/github.com/pb33f/libopenapi-validator/parameters/validate_security.go:58 +0x198
github.com/pb33f/libopenapi-validator/parameters.TestParamValidator_ValidateSecurity_MissingSecuritySchemes(0x1400010e340)
        /Users/k1low/src/github.com/pb33f/libopenapi-validator/parameters/validate_security_test.go:314 +0xa4
testing.tRunner(0x1400010e340, 0x102687aa0)
        /Users/k1low/sdk/go1.22.1/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
        /Users/k1low/sdk/go1.22.1/src/testing/testing.go:1742 +0x318
FAIL    github.com/pb33f/libopenapi-validator/parameters        0.585s
```