### PR TITLE
Added request information to all non-schema validation errors

### DIFF
--- a/errors/error_utilities.go
+++ b/errors/error_utilities.go
@@ -1,0 +1,16 @@
+package errors
+
+import (
+	"net/http"
+)
+
+// PopulateValidationErrors mutates the provided validation errors with additional useful error information, that is
+// not necessarily available when the ValidationError was created and are standard for all errors.
+// Specifically, the RequestPath, SpecPath and RequestMethod are populated.
+func PopulateValidationErrors(validationErrors []*ValidationError, request *http.Request, path string) {
+	for _, validationError := range validationErrors {
+		validationError.SpecPath = path
+		validationError.RequestMethod = request.Method
+		validationError.RequestPath = request.URL.Path
+	}
+}

--- a/errors/request_errors.go
+++ b/errors/request_errors.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pb33f/libopenapi/orderedmap"
 )
 
-func RequestContentTypeNotFound(op *v3.Operation, request *http.Request) *ValidationError {
+func RequestContentTypeNotFound(op *v3.Operation, request *http.Request, specPath string) *ValidationError {
 	ct := request.Header.Get(helpers.ContentTypeHeader)
 	var ctypes []string
 	for pair := orderedmap.First(op.RequestBody.Content); pair != nil; pair = pair.Next() {
@@ -26,23 +26,29 @@ func RequestContentTypeNotFound(op *v3.Operation, request *http.Request) *Valida
 			request.Method, ct),
 		Reason: fmt.Sprintf("The content type '%s' of the %s request submitted has not "+
 			"been defined, it's an unknown type", ct, request.Method),
-		SpecLine: op.RequestBody.GoLow().Content.KeyNode.Line,
-		SpecCol:  op.RequestBody.GoLow().Content.KeyNode.Column,
-		Context:  op,
-		HowToFix: fmt.Sprintf(HowToFixInvalidContentType, orderedmap.Len(op.RequestBody.Content), strings.Join(ctypes, ", ")),
+		SpecLine:      op.RequestBody.GoLow().Content.KeyNode.Line,
+		SpecCol:       op.RequestBody.GoLow().Content.KeyNode.Column,
+		Context:       op,
+		HowToFix:      fmt.Sprintf(HowToFixInvalidContentType, orderedmap.Len(op.RequestBody.Content), strings.Join(ctypes, ", ")),
+		RequestPath:   request.URL.Path,
+		RequestMethod: request.Method,
+		SpecPath:      specPath,
 	}
 }
 
-func OperationNotFound(pathItem *v3.PathItem, request *http.Request, method string) *ValidationError {
+func OperationNotFound(pathItem *v3.PathItem, request *http.Request, method string, specPath string) *ValidationError {
 	return &ValidationError{
 		ValidationType:    helpers.RequestValidation,
 		ValidationSubType: helpers.RequestMissingOperation,
 		Message: fmt.Sprintf("%s operation request content type '%s' does not exist",
 			request.Method, method),
-		Reason:   fmt.Sprintf("The path was found, but there was no '%s' method found in the spec", request.Method),
-		SpecLine: pathItem.GoLow().KeyNode.Line,
-		SpecCol:  pathItem.GoLow().KeyNode.Column,
-		Context:  pathItem,
-		HowToFix: HowToFixPathMethod,
+		Reason:        fmt.Sprintf("The path was found, but there was no '%s' method found in the spec", request.Method),
+		SpecLine:      pathItem.GoLow().KeyNode.Line,
+		SpecCol:       pathItem.GoLow().KeyNode.Column,
+		Context:       pathItem,
+		HowToFix:      HowToFixPathMethod,
+		RequestPath:   request.URL.Path,
+		RequestMethod: request.Method,
+		SpecPath:      specPath,
 	}
 }

--- a/errors/validation_error.go
+++ b/errors/validation_error.go
@@ -75,6 +75,15 @@ type ValidationError struct {
 	// HowToFix is a human-readable message describing how to fix the error.
 	HowToFix string `json:"howToFix" yaml:"howToFix"`
 
+	// RequestPath is the path of the request
+	RequestPath string `json:"requestPath" yaml:"requestPath"`
+
+	// SpecPath is the path from the specification that corresponds to the request
+	SpecPath string `json:"specPath" yaml:"specPath"`
+
+	// RequestMethod is the HTTP method of the request
+	RequestMethod string `json:"requestMethod" yaml:"requestMethod"`
+
 	// SchemaValidationErrors is a slice of SchemaValidationFailure objects that describe the validation errors
 	// This is only populated whe the validation type is against a schema.
 	SchemaValidationErrors []*SchemaValidationFailure `json:"validationErrors,omitempty" yaml:"validationErrors,omitempty"`

--- a/parameters/cookie_parameters.go
+++ b/parameters/cookie_parameters.go
@@ -19,15 +19,18 @@ func (v *paramValidator) ValidateCookieParams(request *http.Request) (bool, []*e
 
 	// find path
 	var pathItem *v3.PathItem
+	var foundPath string
 	var errs []*errors.ValidationError
+
 	if v.pathItem == nil {
-		pathItem, errs, _ = paths.FindPath(request, v.document)
+		pathItem, errs, foundPath = paths.FindPath(request, v.document)
 		if pathItem == nil || errs != nil {
 			v.errors = errs
 			return false, errs
 		}
 	} else {
 		pathItem = v.pathItem
+		foundPath = v.pathValue
 	}
 
 	// extract params for the operation
@@ -121,6 +124,9 @@ func (v *paramValidator) ValidateCookieParams(request *http.Request) (bool, []*e
 			}
 		}
 	}
+
+	errors.PopulateValidationErrors(validationErrors, request, foundPath)
+
 	if len(validationErrors) > 0 {
 		return false, validationErrors
 	}

--- a/parameters/cookie_parameters_test.go
+++ b/parameters/cookie_parameters_test.go
@@ -35,6 +35,9 @@ paths:
 
 	assert.False(t, valid)
 	assert.Len(t, errors, 1)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "", errors[0].SpecPath)
 }
 
 func TestNewValidator_CookieParamNumberValid(t *testing.T) {
@@ -202,6 +205,9 @@ paths:
 	assert.Len(t, errors, 1)
 	assert.Equal(t,
 		"Instead of 'milk', use one of the allowed values: 'beef, chicken, pea protein'", errors[0].HowToFix)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/burgers/beef", errors[0].SpecPath)
 }
 
 func TestNewValidator_CookieParamBooleanInvalid(t *testing.T) {

--- a/parameters/header_parameters.go
+++ b/parameters/header_parameters.go
@@ -19,15 +19,17 @@ import (
 func (v *paramValidator) ValidateHeaderParams(request *http.Request) (bool, []*errors.ValidationError) {
 	// find path
 	var pathItem *v3.PathItem
+	var specPath string
 	var errs []*errors.ValidationError
 	if v.pathItem == nil {
-		pathItem, errs, _ = paths.FindPath(request, v.document)
+		pathItem, errs, specPath = paths.FindPath(request, v.document)
 		if pathItem == nil || errs != nil {
 			v.errors = errs
 			return false, errs
 		}
 	} else {
 		pathItem = v.pathItem
+		specPath = v.pathValue
 	}
 
 	// extract params for the operation
@@ -142,6 +144,8 @@ func (v *paramValidator) ValidateHeaderParams(request *http.Request) (bool, []*e
 			}
 		}
 	}
+
+	errors.PopulateValidationErrors(validationErrors, request, specPath)
 
 	if len(validationErrors) > 0 {
 		return false, validationErrors

--- a/parameters/header_parameters_test.go
+++ b/parameters/header_parameters_test.go
@@ -36,6 +36,9 @@ paths:
 	assert.False(t, valid)
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, "Header parameter 'bash' is missing", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/bish/bosh", errors[0].SpecPath)
 }
 
 func TestNewValidator_HeaderPathMissing(t *testing.T) {
@@ -63,6 +66,9 @@ paths:
 	assert.False(t, valid)
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, "GET Path '/I/do/not/exist' not found", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "", errors[0].SpecPath)
 }
 
 func TestNewValidator_HeaderParamDefaultEncoding_InvalidParamTypeNumber(t *testing.T) {

--- a/parameters/path_parameters.go
+++ b/parameters/path_parameters.go
@@ -276,6 +276,9 @@ func (v *paramValidator) ValidatePathParams(request *http.Request) (bool, []*err
 			}
 		}
 	}
+
+	errors.PopulateValidationErrors(validationErrors, request, foundPath)
+
 	if len(validationErrors) > 0 {
 		return false, validationErrors
 	}

--- a/parameters/path_parameters_test.go
+++ b/parameters/path_parameters_test.go
@@ -68,6 +68,9 @@ paths:
 	assert.False(t, valid)
 	assert.Len(t, errors, 2)
 	assert.Equal(t, "Path array parameter 'burgerIds' is not a valid number", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/burgers/{burgerIds*}/locate", errors[0].SpecPath)
 }
 
 func TestNewValidator_SimpleArrayEncodedPath_InvalidBool(t *testing.T) {

--- a/parameters/query_parameters.go
+++ b/parameters/query_parameters.go
@@ -22,15 +22,17 @@ import (
 func (v *paramValidator) ValidateQueryParams(request *http.Request) (bool, []*errors.ValidationError) {
 	// find path
 	var pathItem *v3.PathItem
+	var foundPath string
 	var errs []*errors.ValidationError
 	if v.pathItem == nil {
-		pathItem, errs, _ = paths.FindPath(request, v.document)
+		pathItem, errs, foundPath = paths.FindPath(request, v.document)
 		if pathItem == nil || errs != nil {
 			v.errors = errs
 			return false, errs
 		}
 	} else {
 		pathItem = v.pathItem
+		foundPath = v.pathValue
 	}
 
 	// extract params for the operation
@@ -210,6 +212,8 @@ doneLooking:
 			}
 		}
 	}
+
+	errors.PopulateValidationErrors(validationErrors, request, foundPath)
 
 	v.errors = validationErrors
 	if len(validationErrors) > 0 {

--- a/parameters/query_parameters_test.go
+++ b/parameters/query_parameters_test.go
@@ -39,6 +39,9 @@ paths:
 	assert.False(t, valid)
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, "Query parameter 'fishy' is missing", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/a/fishy/on/a/dishy", errors[0].SpecPath)
 }
 
 func TestNewValidator_QueryParamNotMissing(t *testing.T) {

--- a/parameters/validate_security_test.go
+++ b/parameters/validate_security_test.go
@@ -40,6 +40,9 @@ components:
 	assert.False(t, valid)
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, "API Key X-API-Key not found in header", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/products", errors[0].SpecPath)
 }
 
 func TestParamValidator_ValidateSecurity_APIKeyHeader(t *testing.T) {
@@ -104,6 +107,9 @@ components:
 	assert.Equal(t, "API Key X-API-Key not found in query", errors[0].Message)
 	assert.Equal(t, "Add an API Key via 'X-API-Key' to the query string of the URL, "+
 		"for example 'https://things.com/products?X-API-Key=your-api-key'", errors[0].HowToFix)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/products", errors[0].SpecPath)
 
 }
 
@@ -166,6 +172,9 @@ components:
 	assert.False(t, valid)
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, "API Key X-API-Key not found in cookies", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/products", errors[0].SpecPath)
 }
 
 func TestParamValidator_ValidateSecurity_APIKeyCookie(t *testing.T) {
@@ -231,6 +240,9 @@ components:
 	assert.False(t, valid)
 	assert.Equal(t, 1, len(errors))
 	assert.Equal(t, "Authorization header for 'basic' scheme", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/products", errors[0].SpecPath)
 }
 
 func TestParamValidator_ValidateSecurity_Basic(t *testing.T) {
@@ -289,6 +301,9 @@ components:
 	valid, errors := v.ValidateSecurity(request)
 	assert.False(t, valid)
 	assert.Equal(t, 1, len(errors))
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "", errors[0].SpecPath)
 }
 
 func TestParamValidator_ValidateSecurity_MissingSecuritySchemes(t *testing.T) {

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -187,8 +187,11 @@ pathFound:
 			SpecCol:  -1,
 			HowToFix: errors.HowToFixPath,
 		})
+
+		errors.PopulateValidationErrors(validationErrors, request, foundPath)
 		return pItem, validationErrors, foundPath
 	} else {
+		errors.PopulateValidationErrors(validationErrors, request, foundPath)
 		return pItem, validationErrors, foundPath
 	}
 }

--- a/requests/validate_body_test.go
+++ b/requests/validate_body_test.go
@@ -149,6 +149,56 @@ paths:
 	assert.Equal(t, "", errors[0].SpecPath)
 }
 
+func TestValidateBody_OperationNotFound(t *testing.T) {
+	spec := `openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                patties:
+                  type: integer
+                vegetarian:
+                  type: boolean`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+
+	m, _ := doc.BuildV3Model()
+	v := NewRequestBodyValidator(&m.Model)
+
+	// mix up the primitives to fire two schema violations.
+	body := map[string]interface{}{
+		"name":       "Big Mac",
+		"patties":    false,
+		"vegetarian": 2,
+	}
+
+	bodyBytes, _ := json.Marshal(body)
+
+	request, _ := http.NewRequest(http.MethodGet, "https://things.com/burgers/createBurger",
+		bytes.NewBuffer(bodyBytes))
+	request.Header.Set("Content-Type", "application/json")
+
+	pathItem := m.Model.Paths.PathItems.First().Value()
+	pathValue := m.Model.Paths.PathItems.First().Key()
+	v.SetPathItem(pathItem, pathValue)
+
+	valid, errors := v.ValidateRequestBody(request)
+
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Equal(t, "GET operation request content type 'GET' does not exist", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/burgers/createBurger", errors[0].SpecPath)
+}
+
 func TestValidateBody_SetPath(t *testing.T) {
 	spec := `openapi: 3.1.0
 paths:

--- a/requests/validate_body_test.go
+++ b/requests/validate_body_test.go
@@ -57,6 +57,9 @@ paths:
 	assert.Equal(t, "POST operation request content type 'thomas/tank-engine' does not exist", errors[0].Message)
 	assert.Equal(t, "The content type is invalid, Use one of the 1 "+
 		"supported types for this operation: application/json", errors[0].HowToFix)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/burgers/createBurger", errors[0].SpecPath)
 }
 
 func TestValidateBody_SkipValidationForNonJSON(t *testing.T) {
@@ -141,6 +144,9 @@ paths:
 	assert.False(t, valid)
 	assert.Len(t, errors, 1)
 	assert.Equal(t, "POST Path '/I do not exist' not found", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "", errors[0].SpecPath)
 }
 
 func TestValidateBody_SetPath(t *testing.T) {

--- a/responses/validate_body.go
+++ b/responses/validate_body.go
@@ -23,15 +23,17 @@ func (v *responseBodyValidator) ValidateResponseBody(
 ) (bool, []*errors.ValidationError) {
 	// find path
 	var pathItem *v3.PathItem
+	var pathFound string
 	var errs []*errors.ValidationError
 	if v.pathItem == nil {
-		pathItem, errs, _ = paths.FindPath(request, v.document)
+		pathItem, errs, pathFound = paths.FindPath(request, v.document)
 		if pathItem == nil || errs != nil {
 			v.errors = errs
 			return false, errs
 		}
 	} else {
 		pathItem = v.pathItem
+		pathFound = v.pathValue
 	}
 
 	var validationErrors []*errors.ValidationError
@@ -88,6 +90,9 @@ func (v *responseBodyValidator) ValidateResponseBody(
 				errors.ResponseCodeNotFound(operation, request, httpCode))
 		}
 	}
+
+	errors.PopulateValidationErrors(validationErrors, request, pathFound)
+
 	if len(validationErrors) > 0 {
 		return false, validationErrors
 	}

--- a/responses/validate_body_test.go
+++ b/responses/validate_body_test.go
@@ -74,6 +74,9 @@ paths:
 	assert.Equal(t, "POST / 200 operation response content type 'cheeky/monkey' does not exist", errors[0].Message)
 	assert.Equal(t, "The content type is invalid, Use one of the 1 "+
 		"supported types for this operation: application/json", errors[0].HowToFix)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/burgers/createBurger", errors[0].SpecPath)
 }
 
 func TestValidateBody_MissingPath(t *testing.T) {
@@ -132,6 +135,9 @@ paths:
 	assert.False(t, valid)
 	assert.Len(t, errors, 1)
 	assert.Equal(t, "POST Path '/I do not exist' not found", errors[0].Message)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "", errors[0].SpecPath)
 }
 
 func TestValidateBody_SetPath(t *testing.T) {


### PR DESCRIPTION
I added some request information to the validation error struct. 

Rather than modifying this in constructors, I figured it would be a lot easier to populate this as the last step during validation. If that's not the right approach, I can convert it to a constructor oriented method.