### PR TITLE
Check and handle compiler err on compile req body

### DIFF
--- a/requests/validate_request.go
+++ b/requests/validate_request.go
@@ -97,7 +97,17 @@ func ValidateRequestSchema(
 
 	compiler := jsonschema.NewCompiler()
 	_ = compiler.AddResource("requestBody.json", strings.NewReader(string(jsonSchema)))
-	jsch, _ := compiler.Compile("requestBody.json")
+	jsch, err := compiler.Compile("requestBody.json")
+	if err != nil {
+		validationErrors = append(validationErrors, &errors.ValidationError{
+			ValidationType:    helpers.RequestBodyValidation,
+			ValidationSubType: helpers.Schema,
+			Message:           err.Error(),
+			Reason:            "Failed to compile the request body for validation.",
+			Context:           string(renderedSchema),
+		})
+		return false, validationErrors
+	}
 
 	// validate the object against the schema
 	scErrs := jsch.Validate(decodedObj)

--- a/requests/validate_request_test.go
+++ b/requests/validate_request_test.go
@@ -1,0 +1,53 @@
+package requests
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateRequestSchema(t *testing.T) {
+	for name, tc := range map[string]struct {
+		request                    *http.Request
+		schema                     *base.Schema
+		renderedSchema, jsonSchema []byte
+		assertValidRequestSchema   assert.BoolAssertionFunc
+		expectedErrorsCount        int
+	}{
+		"FailRequestBodyValidation": {
+			// KeywordLocation: /allOf/1/$ref/properties/properties/additionalProperties/$dynamicRef/allOf/3/$ref/properties/exclusiveMinimum/type
+			// Message: expected number, but got boolean
+			request: &http.Request{
+				Method: http.MethodPost,
+				Body:   io.NopCloser(strings.NewReader(`{"exclusiveNumber": 13}`)),
+			},
+			schema: &base.Schema{
+				Type: []string{"object"},
+			},
+			renderedSchema: []byte(`type: object
+properties:
+    exclusiveNumber:
+        type: number
+        description: This number starts its journey where most numbers are too scared to begin!
+        exclusiveMinimum: true
+        minimum: !!float 10`),
+			jsonSchema:               []byte(`{"properties":{"exclusiveNumber":{"description":"This number starts its journey where most numbers are too scared to begin!","exclusiveMinimum":true,"minimum":10,"type":"number"}},"type":"object"}`),
+			assertValidRequestSchema: assert.False,
+			expectedErrorsCount:      1,
+		},
+	} {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			valid, errors := ValidateRequestSchema(tc.request, tc.schema, tc.renderedSchema, tc.jsonSchema)
+
+			tc.assertValidRequestSchema(t, valid)
+			assert.Len(t, errors, tc.expectedErrorsCount)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces improved error handling for the JSON schema compilation process in the request validation logic. Previously, the code did not handle potential errors from the compiler, which caused the code to panic when attempting to validate the request body.

The change will improve reliability by ensuring that schema compilation errors are gracefully handled, thus improving the stability of the request body schema validation process.
Additionally, this will facilitate quicker debugging and resolution of issues related to invalid schemas.