### PR TITLE
FindPath reports path and operation not found

### DIFF
--- a/errors/validation_error.go
+++ b/errors/validation_error.go
@@ -5,6 +5,7 @@ package errors
 
 import (
 	"fmt"
+
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
@@ -117,4 +118,9 @@ func (v *ValidationError) Error() string {
 // IsPathMissingError returns true if the error has a ValidationType of "path" and a ValidationSubType of "missing"
 func (v *ValidationError) IsPathMissingError() bool {
 	return v.ValidationType == "path" && v.ValidationSubType == "missing"
+}
+
+// IsOperationMissingError returns true if the error has a ValidationType of "request" and a ValidationSubType of "missingOperation"
+func (v *ValidationError) IsOperationMissingError() bool {
+	return v.ValidationType == "path" && v.ValidationSubType == "missingOperation"
 }

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -314,7 +314,29 @@ paths:
 	assert.Nil(t, pathItem)
 	assert.NotNil(t, errs)
 	assert.Equal(t, "HEAD Path '/not/here' not found", errs[0].Message)
+	assert.True(t, errs[0].IsPathMissingError())
 
+}
+
+func TestNewValidator_FindOperationMissing(t *testing.T) {
+
+	spec := `openapi: 3.1.0
+paths:
+  /burgers/{burgerId}:
+    trace:
+      operationId: locateBurger
+`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+	m, _ := doc.BuildV3Model()
+
+	request, _ := http.NewRequest(http.MethodPut, "https://things.com/burgers/12345", nil)
+
+	pathItem, errs, _ := FindPath(request, &m.Model)
+	assert.NotNil(t, pathItem)
+	assert.NotNil(t, errs)
+	assert.Equal(t, "PUT Path '/burgers/12345' not found", errs[0].Message)
+	assert.True(t, errs[0].IsOperationMissingError())
 }
 
 func TestNewValidator_GetLiteralMatch(t *testing.T) {


### PR DESCRIPTION
The idea is to have a more precise error reporting from the FindPath function, before it could yield a path not found validation error, with this proposed change we will have a path not found or operation not found error.

this may be a breaking change for some implementation that were reliant on IsPathMissingError to filter any error regarding a find path validation error