### PR TITLE
fix: add ValidateHttpRequestSync method for synschronous request validation

### DIFF
--- a/requests/validate_body.go
+++ b/requests/validate_body.go
@@ -4,6 +4,7 @@
 package requests
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -31,6 +32,7 @@ func (v *requestBodyValidator) ValidateRequestBody(request *http.Request) (bool,
 
 	operation := helpers.ExtractOperation(request, pathItem)
 	if operation == nil {
+		fmt.Println("HERE!!!!")
 		return false, []*errors.ValidationError{errors.OperationNotFound(pathItem, request, request.Method, foundPath)}
 	}
 	if operation.RequestBody == nil {

--- a/requests/validate_body.go
+++ b/requests/validate_body.go
@@ -4,7 +4,6 @@
 package requests
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -32,7 +31,6 @@ func (v *requestBodyValidator) ValidateRequestBody(request *http.Request) (bool,
 
 	operation := helpers.ExtractOperation(request, pathItem)
 	if operation == nil {
-		fmt.Println("HERE!!!!")
 		return false, []*errors.ValidationError{errors.OperationNotFound(pathItem, request, request.Method, foundPath)}
 	}
 	if operation.RequestBody == nil {

--- a/validator.go
+++ b/validator.go
@@ -4,6 +4,9 @@
 package validator
 
 import (
+	"net/http"
+	"sync"
+
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi-validator/errors"
 	"github.com/pb33f/libopenapi-validator/parameters"
@@ -11,9 +14,7 @@ import (
 	"github.com/pb33f/libopenapi-validator/requests"
 	"github.com/pb33f/libopenapi-validator/responses"
 	"github.com/pb33f/libopenapi-validator/schema_validation"
-	"github.com/pb33f/libopenapi/datamodel/high/v3"
-	"net/http"
-	"sync"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
 // Validator provides a coarse grained interface for validating an OpenAPI 3+ documents.
@@ -27,6 +28,9 @@ type Validator interface {
 	// ValidateHttpRequest will validate an *http.Request object against an OpenAPI 3+ document.
 	// The path, query, cookie and header parameters and request body are validated.
 	ValidateHttpRequest(request *http.Request) (bool, []*errors.ValidationError)
+	// ValidateHttpRequestSync will validate an *http.Request object against an OpenAPI 3+ document syncronously and without spawning any goroutines.
+	// The path, query, cookie and header parameters and request body are validated.
+	ValidateHttpRequestSync(request *http.Request) (bool, []*errors.ValidationError)
 
 	// ValidateHttpResponse will an *http.Response object against an OpenAPI 3+ document.
 	// The response body is validated. The request is only used to extract the correct reponse from the spec.
@@ -274,6 +278,62 @@ func (v *validator) ValidateHttpRequest(request *http.Request) (bool, []*errors.
 	if len(validationErrors) > 0 {
 		return false, validationErrors
 	}
+	return true, nil
+}
+
+func (v *validator) ValidateHttpRequestSync(request *http.Request) (bool, []*errors.ValidationError) {
+	// find path
+	var pathItem *v3.PathItem
+	var pathValue string
+	var errs []*errors.ValidationError
+	if v.foundPath == nil {
+		pathItem, errs, pathValue = paths.FindPath(request, v.v3Model)
+		if pathItem == nil || errs != nil {
+			v.errors = errs
+			return false, errs
+		}
+		v.foundPath = pathItem
+		v.foundPathValue = pathValue
+	} else {
+		pathItem = v.foundPath
+		pathValue = v.foundPathValue
+	}
+
+	// create a new parameter validator
+	paramValidator := v.paramValidator
+	paramValidator.SetPathItem(pathItem, pathValue)
+
+	// create a new request body validator
+	reqBodyValidator := v.requestValidator
+	reqBodyValidator.SetPathItem(pathItem, pathValue)
+
+	validationErrors := make([]*errors.ValidationError, 0)
+
+	paramValidationErrors := make([]*errors.ValidationError, 0)
+	for _, validateFunc := range []validationFunction{
+		paramValidator.ValidatePathParams,
+		paramValidator.ValidateCookieParams,
+		paramValidator.ValidateHeaderParams,
+		paramValidator.ValidateQueryParams,
+		paramValidator.ValidateSecurity,
+	} {
+		valid, pErrs := validateFunc(request)
+		if !valid {
+			paramValidationErrors = append(paramValidationErrors, pErrs...)
+		}
+	}
+
+	valid, pErrs := reqBodyValidator.ValidateRequestBody(request)
+	if !valid {
+		paramValidationErrors = append(paramValidationErrors, pErrs...)
+	}
+
+	validationErrors = append(validationErrors, paramValidationErrors...)
+
+	if len(validationErrors) > 0 {
+		return false, validationErrors
+	}
+
 	return true, nil
 }
 

--- a/validator_examples_test.go
+++ b/validator_examples_test.go
@@ -88,6 +88,44 @@ func ExampleNewValidator_validateHttpRequest() {
 	// Type: parameter, Failure: Path parameter 'petId' is not a valid number
 }
 
+func ExampleNewValidator_validateHttpRequestSync() {
+	// 1. Load the OpenAPI 3+ spec into a byte array
+	petstore, err := os.ReadFile("test_specs/petstorev3.json")
+
+	if err != nil {
+		panic(err)
+	}
+
+	// 2. Create a new OpenAPI document using libopenapi
+	document, docErrs := libopenapi.NewDocument(petstore)
+
+	if docErrs != nil {
+		panic(docErrs)
+	}
+
+	// 3. Create a new validator
+	docValidator, validatorErrs := NewValidator(document)
+
+	if validatorErrs != nil {
+		panic(validatorErrs)
+	}
+
+	// 4. Create a new *http.Request (normally, this would be where the host application will pass in the request)
+	request, _ := http.NewRequest(http.MethodGet, "/pet/NotAValidPetId", nil)
+
+	// 5. Validate!
+	valid, validationErrs := docValidator.ValidateHttpRequestSync(request)
+
+	if !valid {
+		for _, e := range validationErrs {
+			// 5. Handle the error
+			fmt.Printf("Type: %s, Failure: %s\n", e.ValidationType, e.Message)
+		}
+	}
+	// Type: parameter, Failure: Path parameter 'petId' is not a valid number
+	// Output: Type: security, Failure: API Key api_key not found in header
+}
+
 func ExampleNewValidator_validateHttpRequestResponse() {
 	// 1. Load the OpenAPI 3+ spec into a byte array
 	petstore, err := os.ReadFile("test_specs/petstorev3.json")


### PR DESCRIPTION
Implements the feature requested in: https://github.com/pb33f/libopenapi-validator/issues/79