### PR TITLE
Support response content-type not found with range status code.

### DIFF
--- a/responses/validate_body.go
+++ b/responses/validate_body.go
@@ -43,15 +43,19 @@ func (v *responseBodyValidator) ValidateResponseBody(
 	// extract the response code from the response
 	httpCode := response.StatusCode
 	contentType := response.Header.Get(helpers.ContentTypeHeader)
+	codeStr := strconv.Itoa(httpCode)
 
 	// extract the media type from the content type header.
 	mediaTypeSting, _, _ := helpers.ExtractContentType(contentType)
 
 	// check if the response code is in the contract
-	foundResponse := operation.Responses.Codes.GetOrZero(fmt.Sprintf("%d", httpCode))
+	foundResponse := operation.Responses.Codes.GetOrZero(codeStr)
 	if foundResponse == nil {
 		// check range definition for response codes
 		foundResponse = operation.Responses.Codes.GetOrZero(fmt.Sprintf("%dXX", httpCode/100))
+		if foundResponse != nil {
+			codeStr = fmt.Sprintf("%dXX", httpCode/100)
+		}
 	}
 
 	if foundResponse != nil {
@@ -65,7 +69,6 @@ func (v *responseBodyValidator) ValidateResponseBody(
 				if foundResponse.Content != nil && orderedmap.Len(foundResponse.Content) > 0 {
 
 					// content type not found in the contract
-					codeStr := strconv.Itoa(httpCode)
 					validationErrors = append(validationErrors,
 						errors.ResponseContentTypeNotFound(operation, request, response, codeStr, false))
 
@@ -84,7 +87,6 @@ func (v *responseBodyValidator) ValidateResponseBody(
 				if operation.Responses.Default.Content != nil && orderedmap.Len(operation.Responses.Default.Content) > 0 {
 
 					// content type not found in the contract
-					codeStr := strconv.Itoa(httpCode)
 					validationErrors = append(validationErrors,
 						errors.ResponseContentTypeNotFound(operation, request, response, codeStr, true))
 				}

--- a/responses/validate_body_test.go
+++ b/responses/validate_body_test.go
@@ -81,6 +81,65 @@ paths:
 	assert.Equal(t, "/burgers/createBurger", errors[0].SpecPath)
 }
 
+func TestValidateBody_MissingContentType4XX(t *testing.T) {
+	spec := `openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      responses:
+        4XX:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+
+	m, _ := doc.BuildV3Model()
+	v := NewResponseBodyValidator(&m.Model)
+
+	body := map[string]interface{}{
+		"name":       "Big Mac",
+		"patties":    false,
+		"vegetarian": 2,
+	}
+
+	bodyBytes, _ := json.Marshal(body)
+
+	// build a request
+	request, _ := http.NewRequest(http.MethodPost, "https://things.com/burgers/createBurger", bytes.NewReader(bodyBytes))
+	request.Header.Set(helpers.ContentTypeHeader, helpers.JSONContentType)
+
+	// simulate a request/response
+	res := httptest.NewRecorder()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(helpers.ContentTypeHeader, "cheeky/monkey")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(bodyBytes)
+	}
+
+	// fire the request
+	handler(res, request)
+
+	// record response
+	response := res.Result()
+
+	// validate!
+	valid, errors := v.ValidateResponseBody(request, response)
+
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+	assert.Equal(t, "POST / 4XX operation response content type 'cheeky/monkey' does not exist", errors[0].Message)
+	assert.Equal(t, "The content type is invalid, Use one of the 1 "+
+		"supported types for this operation: application/json", errors[0].HowToFix)
+	assert.Equal(t, request.Method, errors[0].RequestMethod)
+	assert.Equal(t, request.URL.Path, errors[0].RequestPath)
+	assert.Equal(t, "/burgers/createBurger", errors[0].SpecPath)
+}
+
 func TestValidateBody_MissingPath(t *testing.T) {
 	spec := `openapi: 3.1.0
 paths:


### PR DESCRIPTION
Fix panics caused by ResponseContentTypeNotFound in the case of a response with a range status code.