### PR TITLE
Address #78

### DIFF
--- a/errors/parameter_errors.go
+++ b/errors/parameter_errors.go
@@ -2,11 +2,12 @@ package errors
 
 import (
 	"fmt"
-	"github.com/pb33f/libopenapi-validator/helpers"
-	"github.com/pb33f/libopenapi/datamodel/high/base"
-	"github.com/pb33f/libopenapi/datamodel/high/v3"
 	"net/url"
 	"strings"
+
+	"github.com/pb33f/libopenapi-validator/helpers"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
 func IncorrectFormEncoding(param *v3.Parameter, qp *helpers.QueryParam, i int) *ValidationError {
@@ -466,5 +467,18 @@ func IncorrectPathParamArrayBoolean(
 		SpecCol:  sch.Items.A.GoLow().Schema().Type.KeyNode.Column,
 		Context:  itemsSchema,
 		HowToFix: fmt.Sprintf(HowToFixParamInvalidBoolean, item),
+	}
+}
+
+func PathParameterMissing(param *v3.Parameter) *ValidationError {
+	return &ValidationError{
+		ValidationType:    helpers.ParameterValidation,
+		ValidationSubType: helpers.ParameterValidationPath,
+		Message:           fmt.Sprintf("Path parameter '%s' is missing", param.Name),
+		Reason: fmt.Sprintf("The path parameter '%s' is defined as being required, "+
+			"however it's missing from the requests", param.Name),
+		SpecLine: param.GoLow().Required.KeyNode.Line,
+		SpecCol:  param.GoLow().Required.KeyNode.Column,
+		HowToFix: HowToFixMissingValue,
 	}
 }

--- a/parameters/path_parameters.go
+++ b/parameters/path_parameters.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pb33f/libopenapi-validator/helpers"
 	"github.com/pb33f/libopenapi-validator/paths"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
-	"github.com/pb33f/libopenapi/datamodel/high/v3"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
 func (v *paramValidator) ValidatePathParams(request *http.Request) (bool, []*errors.ValidationError) {
@@ -85,7 +85,10 @@ func (v *paramValidator) ValidatePathParams(request *http.Request) (bool, []*err
 					}
 
 					if paramValue == "" {
-						// TODO: check path match issue.
+						//Mandatory path parameter cannot be empty
+						if p.Required != nil && *p.Required {
+							validationErrors = append(validationErrors, errors.PathParameterMissing(p))
+						}
 						continue
 					}
 

--- a/parameters/path_parameters_test.go
+++ b/parameters/path_parameters_test.go
@@ -1436,3 +1436,31 @@ paths:
 	assert.True(t, valid)
 	assert.Len(t, errors, 0)
 }
+func TestNewValidator_MandatorydPathSegmentEmpty(t *testing.T) {
+
+	spec := `openapi: 3.1.0
+servers:
+- url: https://api.pb33f.io
+  description: Live production endpoint for general use.
+paths:
+  /burgers/{burger}:
+    get:
+      parameters:
+        - name: burger
+          in: path
+          required: true
+          schema:
+            type: string`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+
+	m, _ := doc.BuildV3Model()
+
+	v := NewParameterValidator(&m.Model)
+
+	request, _ := http.NewRequest(http.MethodGet, "https://things.com/burgers/", nil)
+	valid, errors := v.ValidatePathParams(request)
+
+	assert.False(t, valid)
+	assert.Len(t, errors, 1)
+}


### PR DESCRIPTION
@daveshanley - For a path parameter which is marked as required , empty value should not be allowed. Ideally , in this case , we do not need to proceed towards enum check as the absence of a value should violate the mandatory path parameter requirement criteria irrespective of the schema of path parameter