### PR TITLE
fix: check for empty body in response using http.NoBody

### DIFF
--- a/responses/validate_body_test.go
+++ b/responses/validate_body_test.go
@@ -532,7 +532,9 @@ paths:
 	response := &http.Response{
 		Header:     http.Header{},
 		StatusCode: http.StatusOK,
-		Body:       nil, // invalid response body
+		// The http Client and Transport guarantee that Body is always non-nil
+		// and will be set to [http.NoBody] if no body is present.
+		Body: http.NoBody,
 	}
 	response.Header.Set(helpers.ContentTypeHeader, helpers.JSONContentType)
 

--- a/responses/validate_response.go
+++ b/responses/validate_response.go
@@ -45,7 +45,7 @@ func ValidateResponseSchema(
 
 	var validationErrors []*errors.ValidationError
 
-	if response == nil || response.Body == nil {
+	if response == nil || response.Body == http.NoBody {
 		// cannot decode the response body, so it's not valid
 		violation := &errors.SchemaValidationFailure{
 			Reason:          "response is empty",


### PR DESCRIPTION
# What : 

- Check that the response body is empty by using the [http.NoBody] variable as the http.Client and http.Transport always guarantees that the body will never be nil hence the condition `response.Body == nil` is irrelevant in real word scenarios. 
- Adjust test accordingly

source : 

https://cs.opensource.google/go/go/+/refs/tags/go1.24.1:src/net/http/response.go
```
	// Body represents the response body.
	//
	// The response body is streamed on demand as the Body field
	// is read. If the network connection fails or the server
	// terminates the response, Body.Read calls return an error.
	//
	// The http Client and Transport guarantee that Body is always
	// non-nil, even on responses without a body or responses with
	// a zero-length body. It is the caller's responsibility to
	// close Body. The default HTTP client's Transport may not
	// reuse HTTP/1.x "keep-alive" TCP connections if the Body is
	// not read to completion and closed.
	//
	// The Body is automatically dechunked if the server replied
	// with a "chunked" Transfer-Encoding.
	//
	// As of Go 1.12, the Body will also implement io.Writer
	// on a successful "101 Switching Protocols" response,
	// as used by WebSockets and HTTP/2's "h2c" mode.
	Body io.ReadCloser
```

# Suggestion : 

Maybe we could adjust the test to use an http.TestServer and issue requests to it in order to simulate real world scenarios ? 
Happy to do another PR to introduce these changes if you wish. 