### PR TITLE
fix: pass validator config options when validating OpenAPI doc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pb33f/libopenapi-validator
 go 1.23.0
 
 require (
+	github.com/dlclark/regexp2 v1.11.0
 	github.com/pb33f/libopenapi v0.21.8
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/stretchr/testify v1.10.0

--- a/validator.go
+++ b/validator.go
@@ -105,7 +105,11 @@ func (v *validator) GetResponseBodyValidator() responses.ResponseBodyValidator {
 }
 
 func (v *validator) ValidateDocument() (bool, []*errors.ValidationError) {
-	return schema_validation.ValidateOpenAPIDocument(v.document)
+	var validationOpts []config.Option
+	if v.options != nil {
+		validationOpts = append(validationOpts, config.WithRegexEngine(v.options.RegexEngine))
+	}
+	return schema_validation.ValidateOpenAPIDocument(v.document, validationOpts...)
 }
 
 func (v *validator) ValidateHttpResponse(

--- a/validator.go
+++ b/validator.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 
 	"github.com/pb33f/libopenapi"
+
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+
 	"github.com/pb33f/libopenapi-validator/config"
 	"github.com/pb33f/libopenapi-validator/errors"
 	"github.com/pb33f/libopenapi-validator/parameters"
@@ -15,7 +18,6 @@ import (
 	"github.com/pb33f/libopenapi-validator/requests"
 	"github.com/pb33f/libopenapi-validator/responses"
 	"github.com/pb33f/libopenapi-validator/schema_validation"
-	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
 // Validator provides a coarse grained interface for validating an OpenAPI 3+ documents.

--- a/validator.go
+++ b/validator.go
@@ -8,9 +8,6 @@ import (
 	"sync"
 
 	"github.com/pb33f/libopenapi"
-
-	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
-
 	"github.com/pb33f/libopenapi-validator/config"
 	"github.com/pb33f/libopenapi-validator/errors"
 	"github.com/pb33f/libopenapi-validator/parameters"
@@ -18,6 +15,7 @@ import (
 	"github.com/pb33f/libopenapi-validator/requests"
 	"github.com/pb33f/libopenapi-validator/responses"
 	"github.com/pb33f/libopenapi-validator/schema_validation"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
 // Validator provides a coarse grained interface for validating an OpenAPI 3+ documents.

--- a/validator_test.go
+++ b/validator_test.go
@@ -18,12 +18,14 @@ import (
 
 	"github.com/dlclark/regexp2"
 	"github.com/pb33f/libopenapi"
-	"github.com/pb33f/libopenapi-validator/config"
-	"github.com/pb33f/libopenapi-validator/helpers"
-	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+
+	"github.com/pb33f/libopenapi-validator/config"
+	"github.com/pb33f/libopenapi-validator/helpers"
 )
 
 func TestNewValidator(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -19,13 +19,11 @@ import (
 	"github.com/dlclark/regexp2"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi-validator/config"
+	"github.com/pb33f/libopenapi-validator/helpers"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
-
-	"github.com/pb33f/libopenapi-validator/helpers"
 )
 
 func TestNewValidator(t *testing.T) {


### PR DESCRIPTION
Currently, when initializing validator.NewValidator with a custom regex engine, that engine is not passed down to the `ValidateDocument()` function.

For example:
```
validator, errs := validator.NewValidator(doc, config.WithRegexEngine(customRegexEngine))
if len(errs) > 0 {
	log.Fatal(errs)
	return 
}
docValid, valErrors := validator.ValidateDocument()
if len(valErrors) > 0 {
	log.Fatal(valErrors)
	return
}
```
In this case, although config.WithRegexEngine(customRegexEngine) is provided during initialization, it is not used during validation, because ValidateDocument() does not forward the option.

This PR resolves the issue by ensuring v.options.RegexEngine is passed into ValidateOpenAPIDocument using the config.WithRegexEngine option. This ensures that any custom regex engine specified during initialization is correctly applied when validating OpenAPI documents.