### PR TITLE
Check items when validating enums in array query parameters.

### DIFF
--- a/parameters/query_parameters_test.go
+++ b/parameters/query_parameters_test.go
@@ -969,6 +969,37 @@ paths:
 		"however the value 'haddock' is not a valid number", errors[1].Reason)
 }
 
+func TestNewValidator_QueryParamValidEnumStringType(t *testing.T) {
+	spec := `openapi: 3.1.0
+paths:
+ /a/fishy/on/a/dishy:
+   get:
+     parameters:
+       - name: fishy
+         in: query
+         required: true
+         schema:
+           type: array
+           items:
+             type: string
+             enum: [cod, haddock]
+     operationId: locateFishy
+`
+
+	doc, _ := libopenapi.NewDocument([]byte(spec))
+
+	m, _ := doc.BuildV3Model()
+
+	v := NewParameterValidator(&m.Model)
+
+	request, _ := http.NewRequest(http.MethodGet, "https://things.com/a/fishy/on/a/dishy?fishy=cod,haddock", nil)
+
+	valid, errors := v.ValidateQueryParams(request)
+	assert.True(t, valid)
+
+	assert.Len(t, errors, 0)
+}
+
 func TestNewValidator_QueryParamValidExplodedType(t *testing.T) {
 	spec := `openapi: 3.1.0
 paths:

--- a/parameters/validation_functions.go
+++ b/parameters/validation_functions.go
@@ -127,14 +127,14 @@ func ValidateQueryArray(
 	}
 
 	// check if the param is within an enum
-	checkEnum := func(enumCheck, item string) {
+	checkEnum := func(item string) {
 		// check if the array param is within an enum
 		if sch.Items.IsA() {
 			itemsSch := sch.Items.A.Schema()
 			if itemsSch.Enum != nil {
 				matchFound := false
 				for _, enumVal := range itemsSch.Enum {
-					if strings.TrimSpace(enumCheck) == fmt.Sprint(enumVal.Value) {
+					if strings.TrimSpace(item) == fmt.Sprint(enumVal.Value) {
 						matchFound = true
 						break
 					}
@@ -159,7 +159,7 @@ func ValidateQueryArray(
 					break
 				}
 				// will it blend?
-				checkEnum(ef, item)
+				checkEnum(item)
 
 			case helpers.Boolean:
 				if _, err := strconv.ParseBool(item); err != nil {
@@ -180,7 +180,7 @@ func ValidateQueryArray(
 			case helpers.String:
 
 				// will it float?
-				checkEnum(ef, item)
+				checkEnum(item)
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #146.

Check the item against the enum definition when validating arrays of query parameters. Previously, the unparsed query parameter value was used. This was problematic for non-exploded-form-style-arrays. In that case, validation errors would be thrown for correct requests. For example, if you accept only `cod` and `haddock`, and the parameter is set to `cod,haddock`, it'd test `cod,haddock` instead of `cod` and `haddock`.