### PR TITLE
feat: Add possibility to register custom formats and their validators.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ type ValidationOptions struct {
 	RegexEngine       jsonschema.RegexpEngine
 	FormatAssertions  bool
 	ContentAssertions bool
+	Formats           map[string]func(v any) error
 }
 
 // Option Enables an 'Options pattern' approach
@@ -39,6 +40,7 @@ func WithExistingOpts(options *ValidationOptions) Option {
 		o.RegexEngine = options.RegexEngine
 		o.FormatAssertions = options.FormatAssertions
 		o.ContentAssertions = options.ContentAssertions
+		o.Formats = options.Formats
 	}
 }
 
@@ -60,5 +62,18 @@ func WithFormatAssertions() Option {
 func WithContentAssertions() Option {
 	return func(o *ValidationOptions) {
 		o.ContentAssertions = true
+	}
+}
+
+// WithCustomFormat adds custom formats and their validators that checks for custom 'format' assertions
+// When you add different validators with the same name, they will be overridden,
+// and only the last registration will take effect.
+func WithCustomFormat(name string, validator func(v any) error) Option {
+	return func(o *ValidationOptions) {
+		if o.Formats == nil {
+			o.Formats = make(map[string]func(v any) error)
+		}
+
+		o.Formats[name] = validator
 	}
 }

--- a/helpers/schema_compiler.go
+++ b/helpers/schema_compiler.go
@@ -28,6 +28,14 @@ func ConfigureCompiler(c *jsonschema.Compiler, o *config.ValidationOptions) {
 	if o.ContentAssertions {
 		c.AssertContent()
 	}
+
+	// Register custom formats
+	for n, v := range o.Formats {
+		c.RegisterFormat(&jsonschema.Format{
+			Name:     n,
+			Validate: v,
+		})
+	}
 }
 
 // NewCompilerWithOptions mints a new JSON schema compiler with custom configuration.

--- a/helpers/schema_compiler_test.go
+++ b/helpers/schema_compiler_test.go
@@ -1,7 +1,9 @@
 package helpers
 
 import (
+	"fmt"
 	"testing"
+	"unicode"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +24,11 @@ const objectSchema = `{
   "properties" : {
      "name" : {
 	    "type": "string",
+        "description": "The given name of the fish"
+     },
+	"name" : {
+	    "type": "string",
+		"format": "capital",
         "description": "The given name of the fish"
      },
      "species" : {
@@ -47,7 +54,28 @@ func Test_SchemaWithDefaultOptions(t *testing.T) {
 }
 
 func Test_SchemaWithOptions(t *testing.T) {
-	valOptions := config.NewValidationOptions(config.WithFormatAssertions(), config.WithContentAssertions())
+	valOptions := config.NewValidationOptions(
+		config.WithFormatAssertions(),
+		config.WithContentAssertions(),
+		config.WithCustomFormat("capital", func(v any) error {
+			s, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("expected string")
+			}
+
+			if s == "" {
+				return nil
+			}
+
+			r := []rune(s)[0]
+
+			if !unicode.IsUpper(r) {
+				return fmt.Errorf("expected first latter to be uppercase")
+			}
+
+			return nil
+		}),
+	)
 
 	jsch, err := NewCompiledSchema("test", []byte(stringSchema), valOptions)
 


### PR DESCRIPTION
Resolves #152 

Added new configuration option `Formats` that allows you to register custom formats and their validators.

Usage:

```go
v, err := NewValidator(
    document,
    config.WithFormatAssertions(), // required to enable format assertions
    config.WithCustomFormat("capital", func(v any) error {
        s, ok := v.(string)
	if !ok {
		return fmt.Errorf("expected string")
	}

	if s == "" {
		return nil
	}

	r := []rune(s)[0]

	if !unicode.IsUpper(r) {
		return fmt.Errorf("expected first latter to be uppercase")
	}

	return nil
    }),
)
```