### PR TITLE
feat: flag to allow converting from yaml to json pre validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ go get github.com/pb33f/libopenapi-validator
 ## Validate OpenAPI Document
 
 ```bash
-go run github.com/pb33f/libopenapi-validator/cmd/validate@latest [--regexengine] <file>
+go run github.com/pb33f/libopenapi-validator/cmd/validate@latest [--regexengine] [--yaml2json] <file>
 ```
+
+### Options
+
+#### --regexengine
 🔍 Example: Use a custom regex engine/flag (e.g., ecmascript)
 ```bash
 go run github.com/pb33f/libopenapi-validator/cmd/validate@latest --regexengine=ecmascript <file>
@@ -50,6 +54,26 @@ go run github.com/pb33f/libopenapi-validator/cmd/validate@latest --regexengine=e
 - ecmascript
 - re2
 - unicode
+
+#### --yaml2json
+🔍 Convert YAML files to JSON before validation (ℹ️ Default: false)
+
+[libopenapi](https://github.com/pb33f/libopenapi/blob/main/datamodel/spec_info.go#L115) passes `map[interface{}]interface{}` structures for deeply nested objects or complex mappings in the OpenAPI specification, which are not allowed in JSON.
+These structures cannot be properly converted to JSON by libopenapi and cannot be validated by jsonschema, resulting in ambiguous errors.
+
+This flag allows pre-converting from YAML to JSON to bypass this limitation of the libopenapi.
+
+**When does this happen?**
+- OpenAPI specs with deeply nested schema definitions
+- Complex `allOf`, `oneOf`, or `anyOf` structures with multiple levels
+- Specifications with intricate object mappings in examples or schema properties
+
+Enabling this flag pre-converts the YAML document from YAML to JSON, ensuring a clean JSON structure before validation.
+
+Example:
+```bash
+go run github.com/pb33f/libopenapi-validator/cmd/validate@latest --yaml2json <file>
+```
 
 ## Documentation
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/pb33f/libopenapi-validator
 go 1.24.7
 
 require (
+	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad
 	github.com/dlclark/regexp2 v1.11.5
+	github.com/goccy/go-yaml v1.18.0
 	github.com/pb33f/jsonpath v0.1.2
 	github.com/pb33f/libopenapi v0.28.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
@@ -14,7 +16,6 @@ require (
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,8 @@
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basgys/goxml2json v1.1.0 h1:4ln5i4rseYfXNd86lGEB+Vi652IsIXIvggKM/BhUKVw=
-github.com/basgys/goxml2json v1.1.0/go.mod h1:wH7a5Np/Q4QoECFIU8zTQlZwZkrilY0itPfecMw41Dw=
 github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad h1:3swAvbzgfaI6nKuDDU7BiKfZRdF+h2ZwKgMHd8Ha4t8=
 github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad/go.mod h1:9+nBLYNWkvPcq9ep0owWUsPTLgL9ZXTsZWcCSVGGLJ0=
+github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -12,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
[libopenapi](https://github.com/pb33f/libopenapi/blob/main/datamodel/spec_info.go#L115) passes `map[interface{}]interface{}` structures for deeply nested objects or complex mappings in the OpenAPI specification, which are not allowed in JSON. These structures cannot be properly converted to JSON by libopenapi and cannot be validated by jsonschema, resulting in ambiguous errors.

This flag allows pre-converting from YAML to JSON to bypass this limitation of the libopenapi.

This is a workaround to bypass this limitation at the moment. 