### PR TITLE
perf: Add schema caching to parameter validation

### DIFF
--- a/parameters/cookie_parameters.go
+++ b/parameters/cookie_parameters.go
@@ -4,7 +4,6 @@
 package parameters
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -70,13 +69,8 @@ func (v *paramValidator) ValidateCookieParamsWithPathItem(request *http.Request,
 				sch = p.Schema.Schema()
 			}
 
-			// Render schema once for ReferenceSchema field in errors
-			var renderedSchema string
-			if sch != nil {
-				rendered, _ := sch.RenderInline()
-				schemaBytes, _ := json.Marshal(rendered)
-				renderedSchema = string(schemaBytes)
-			}
+			// Get rendered schema for ReferenceSchema field in errors (uses cache if available)
+			renderedSchema := GetRenderedSchema(sch, v.options)
 
 			pType := sch.Type
 

--- a/parameters/header_parameters.go
+++ b/parameters/header_parameters.go
@@ -4,7 +4,6 @@
 package parameters
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -60,13 +59,8 @@ func (v *paramValidator) ValidateHeaderParamsWithPathItem(request *http.Request,
 					sch = p.Schema.Schema()
 				}
 
-				// Render schema once for ReferenceSchema field in errors
-				var renderedSchema string
-				if sch != nil {
-					rendered, _ := sch.RenderInline()
-					schemaBytes, _ := json.Marshal(rendered)
-					renderedSchema = string(schemaBytes)
-				}
+				// Get rendered schema for ReferenceSchema field in errors (uses cache if available)
+				renderedSchema := GetRenderedSchema(sch, v.options)
 
 				pType := sch.Type
 
@@ -204,15 +198,10 @@ func (v *paramValidator) ValidateHeaderParamsWithPathItem(request *http.Request,
 				}
 			} else {
 				if p.Required != nil && *p.Required {
-					// Render schema for missing required parameter
+					// Get rendered schema for missing required parameter (uses cache if available)
 					var renderedSchema string
 					if p.Schema != nil {
-						sch := p.Schema.Schema()
-						if sch != nil {
-							rendered, _ := sch.RenderInline()
-							schemaBytes, _ := json.Marshal(rendered)
-							renderedSchema = string(schemaBytes)
-						}
+						renderedSchema = GetRenderedSchema(p.Schema.Schema(), v.options)
 					}
 					validationErrors = append(validationErrors, errors.HeaderParameterMissing(p, pathValue, operation, renderedSchema))
 				}

--- a/parameters/path_parameters.go
+++ b/parameters/path_parameters.go
@@ -4,7 +4,6 @@
 package parameters
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -142,13 +141,8 @@ func (v *paramValidator) ValidatePathParamsWithPathItem(request *http.Request, p
 					// extract the schema from the parameter
 					sch := p.Schema.Schema()
 
-					// Render schema once for ReferenceSchema field in errors
-					var renderedSchema string
-					if sch != nil {
-						rendered, _ := sch.RenderInline()
-						schemaBytes, _ := json.Marshal(rendered)
-						renderedSchema = string(schemaBytes)
-					}
+					// Get rendered schema for ReferenceSchema field in errors (uses cache if available)
+					renderedSchema := GetRenderedSchema(sch, v.options)
 
 					// check enum (if present)
 					enumCheck := func(decodedValue string) {
@@ -309,13 +303,8 @@ func (v *paramValidator) ValidatePathParamsWithPathItem(request *http.Request, p
 								if sch.Items != nil && sch.Items.IsA() {
 									iSch := sch.Items.A.Schema()
 
-									// Render items schema once for ReferenceSchema field in array errors
-									var renderedItemsSchema string
-									if iSch != nil {
-										rendered, _ := iSch.RenderInline()
-										schemaBytes, _ := json.Marshal(rendered)
-										renderedItemsSchema = string(schemaBytes)
-									}
+									// Get rendered items schema for ReferenceSchema field in errors (uses cache if available)
+									renderedItemsSchema := GetRenderedSchema(iSch, v.options)
 
 									for n := range iSch.Type {
 										// determine how to explode the array

--- a/parameters/query_parameters.go
+++ b/parameters/query_parameters.go
@@ -121,13 +121,8 @@ doneLooking:
 						}
 					}
 
-					// Render schema once for ReferenceSchema field in errors
-					var renderedSchema string
-					if sch != nil {
-						rendered, _ := sch.RenderInline()
-						schemaBytes, _ := json.Marshal(rendered)
-						renderedSchema = string(schemaBytes)
-					}
+					// Get rendered schema for ReferenceSchema field in errors (uses cache if available)
+					renderedSchema := GetRenderedSchema(sch, v.options)
 
 					pType := sch.Type
 
@@ -263,12 +258,8 @@ doneLooking:
 							break
 						}
 					}
-					var renderedSchema string
-					if sch != nil {
-						rendered, _ := sch.RenderInline()
-						schemaBytes, _ := json.Marshal(rendered)
-						renderedSchema = string(schemaBytes)
-					}
+					// Get rendered schema for ReferenceSchema field in errors (uses cache if available)
+					renderedSchema := GetRenderedSchema(sch, v.options)
 					validationErrors = append(validationErrors, errors.QueryParameterMissing(params[p], pathValue, operation, renderedSchema))
 				}
 			}

--- a/parameters/validate_parameter.go
+++ b/parameters/validate_parameter.go
@@ -18,6 +18,7 @@ import (
 
 	stdError "errors"
 
+	"github.com/pb33f/libopenapi-validator/cache"
 	"github.com/pb33f/libopenapi-validator/config"
 	"github.com/pb33f/libopenapi-validator/errors"
 	"github.com/pb33f/libopenapi-validator/helpers"
@@ -35,16 +36,41 @@ func ValidateSingleParameterSchema(
 	pathTemplate string,
 	operation string,
 ) (validationErrors []*errors.ValidationError) {
-	// Get the JSON Schema for the parameter definition.
-	jsonSchema, err := buildJsonRender(schema)
-	if err != nil {
-		return validationErrors
+	var jsch *jsonschema.Schema
+	var jsonSchema []byte
+
+	// Try cache lookup first - avoids expensive schema compilation on each request
+	if o != nil && o.SchemaCache != nil && schema != nil && schema.GoLow() != nil {
+		hash := schema.GoLow().Hash()
+		if cached, ok := o.SchemaCache.Load(hash); ok && cached != nil && cached.CompiledSchema != nil {
+			jsch = cached.CompiledSchema
+		}
 	}
 
-	// Attempt to compile the JSON Schema
-	jsch, err := helpers.NewCompiledSchema(name, jsonSchema, o)
-	if err != nil {
-		return validationErrors
+	// Cache miss - compile the schema
+	if jsch == nil {
+		// Get the JSON Schema for the parameter definition.
+		var err error
+		jsonSchema, err = buildJsonRender(schema)
+		if err != nil {
+			return validationErrors
+		}
+
+		// Attempt to compile the JSON Schema
+		jsch, err = helpers.NewCompiledSchema(name, jsonSchema, o)
+		if err != nil {
+			return validationErrors
+		}
+
+		// Store in cache for future requests
+		if o != nil && o.SchemaCache != nil && schema != nil && schema.GoLow() != nil {
+			hash := schema.GoLow().Hash()
+			o.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
+				Schema:         schema,
+				RenderedJSON:   jsonSchema,
+				CompiledSchema: jsch,
+			})
+		}
 	}
 
 	// Validate the object and report any errors.
@@ -94,13 +120,60 @@ func ValidateParameterSchema(
 	validationOptions *config.ValidationOptions,
 ) []*errors.ValidationError {
 	var validationErrors []*errors.ValidationError
+	var jsch *jsonschema.Schema
+	var jsonSchema []byte
 
-	// 1. build a JSON render of the schema.
-	renderCtx := base.NewInlineRenderContextForValidation()
-	renderedSchema, _ := schema.RenderInlineWithContext(renderCtx)
-	jsonSchema, _ := utils.ConvertYAMLtoJSON(renderedSchema)
+	// Try cache lookup first - avoids expensive schema compilation on each request
+	if validationOptions != nil && validationOptions.SchemaCache != nil && schema != nil && schema.GoLow() != nil {
+		hash := schema.GoLow().Hash()
+		if cached, ok := validationOptions.SchemaCache.Load(hash); ok && cached != nil && cached.CompiledSchema != nil {
+			jsch = cached.CompiledSchema
+			jsonSchema = cached.RenderedJSON
+		}
+	}
 
-	// 2. decode the object into a json blob.
+	// Cache miss - render and compile the schema
+	if jsch == nil {
+		// 1. build a JSON render of the schema.
+		renderCtx := base.NewInlineRenderContextForValidation()
+		renderedSchema, _ := schema.RenderInlineWithContext(renderCtx)
+		referenceSchema := string(renderedSchema)
+		jsonSchema, _ = utils.ConvertYAMLtoJSON(renderedSchema)
+
+		// 2. create a new json schema compiler and add the schema to it
+		var err error
+		jsch, err = helpers.NewCompiledSchema(name, jsonSchema, validationOptions)
+		if err != nil {
+			// schema compilation failed, return validation error instead of panicking
+			validationErrors = append(validationErrors, &errors.ValidationError{
+				ValidationType:    validationType,
+				ValidationSubType: subValType,
+				Message:           fmt.Sprintf("%s '%s' failed schema compilation", entity, name),
+				Reason: fmt.Sprintf("%s '%s' schema compilation failed: %s",
+					reasonEntity, name, err.Error()),
+				SpecLine:      1,
+				SpecCol:       0,
+				ParameterName: name,
+				HowToFix:      "check the parameter schema for invalid JSON Schema syntax, complex regex patterns, or unsupported schema constructs",
+				Context:       string(jsonSchema),
+			})
+			return validationErrors
+		}
+
+		// Store in cache for future requests
+		if validationOptions != nil && validationOptions.SchemaCache != nil && schema != nil && schema.GoLow() != nil {
+			hash := schema.GoLow().Hash()
+			validationOptions.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
+				Schema:          schema,
+				RenderedInline:  renderedSchema,
+				ReferenceSchema: referenceSchema,
+				RenderedJSON:    jsonSchema,
+				CompiledSchema:  jsch,
+			})
+		}
+	}
+
+	// 3. decode the object into a json blob.
 	var decodedObj interface{}
 	rawIsMap := false
 	validEncoding := false
@@ -124,24 +197,6 @@ func ValidateParameterSchema(
 			decodedObj = rawBlob
 		}
 		validEncoding = true
-	}
-	// 3. create a new json schema compiler and add the schema to it
-	jsch, err := helpers.NewCompiledSchema(name, jsonSchema, validationOptions)
-	if err != nil {
-		// schema compilation failed, return validation error instead of panicking
-		validationErrors = append(validationErrors, &errors.ValidationError{
-			ValidationType:    validationType,
-			ValidationSubType: subValType,
-			Message:           fmt.Sprintf("%s '%s' failed schema compilation", entity, name),
-			Reason: fmt.Sprintf("%s '%s' schema compilation failed: %s",
-				reasonEntity, name, err.Error()),
-			SpecLine:      1,
-			SpecCol:       0,
-			ParameterName: name,
-			HowToFix:      "check the parameter schema for invalid JSON Schema syntax, complex regex patterns, or unsupported schema constructs",
-			Context:       string(jsonSchema),
-		})
-		return validationErrors
 	}
 
 	// 4. validate the object against the schema

--- a/parameters/validate_parameter.go
+++ b/parameters/validate_parameter.go
@@ -109,7 +109,7 @@ func buildJsonRender(schema *base.Schema) ([]byte, error) {
 	return utils.ConvertYAMLtoJSON(renderedSchema)
 }
 
-// GetRenderedSchema returns a JSON string representation of the schema for error messages.
+// GetRenderedSchema returns a YAML string representation of the schema for error messages.
 // It first checks the schema cache for a pre-rendered version, falling back to fresh rendering.
 // This avoids expensive re-rendering on each validation when the cache is available.
 func GetRenderedSchema(schema *base.Schema, opts *config.ValidationOptions) string {
@@ -120,15 +120,14 @@ func GetRenderedSchema(schema *base.Schema, opts *config.ValidationOptions) stri
 	// Try cache lookup first
 	if opts != nil && opts.SchemaCache != nil && schema.GoLow() != nil {
 		hash := schema.GoLow().Hash()
-		if cached, ok := opts.SchemaCache.Load(hash); ok && cached != nil && len(cached.RenderedJSON) > 0 {
-			return string(cached.RenderedJSON)
+		if cached, ok := opts.SchemaCache.Load(hash); ok && cached != nil && len(cached.RenderedInline) > 0 {
+			return string(cached.RenderedInline)
 		}
 	}
 
-	// Cache miss - render fresh
+	// Cache miss - render fresh as YAML
 	rendered, _ := schema.RenderInline()
-	schemaBytes, _ := json.Marshal(rendered)
-	return string(schemaBytes)
+	return string(rendered)
 }
 
 // ValidateParameterSchema will validate a parameter against a raw object, or a blob of json/yaml.
@@ -334,8 +333,7 @@ func formatJsonSchemaValidationError(schema *base.Schema, scErrs *jsonschema.Val
 			renderCtx := base.NewInlineRenderContextForValidation()
 			rendered, err := schema.RenderInlineWithContext(renderCtx)
 			if err == nil && rendered != nil {
-				renderedBytes, _ := json.Marshal(rendered)
-				fail.ReferenceSchema = string(renderedBytes)
+				fail.ReferenceSchema = string(rendered)
 			}
 		}
 		schemaValidationErrors = append(schemaValidationErrors, fail)

--- a/parameters/validate_parameter.go
+++ b/parameters/validate_parameter.go
@@ -97,6 +97,28 @@ func buildJsonRender(schema *base.Schema) ([]byte, error) {
 	return utils.ConvertYAMLtoJSON(renderedSchema)
 }
 
+// GetRenderedSchema returns a JSON string representation of the schema for error messages.
+// It first checks the schema cache for a pre-rendered version, falling back to fresh rendering.
+// This avoids expensive re-rendering on each validation when the cache is available.
+func GetRenderedSchema(schema *base.Schema, opts *config.ValidationOptions) string {
+	if schema == nil {
+		return ""
+	}
+
+	// Try cache lookup first
+	if opts != nil && opts.SchemaCache != nil && schema.GoLow() != nil {
+		hash := schema.GoLow().Hash()
+		if cached, ok := opts.SchemaCache.Load(hash); ok && cached != nil && len(cached.RenderedJSON) > 0 {
+			return string(cached.RenderedJSON)
+		}
+	}
+
+	// Cache miss - render fresh
+	rendered, _ := schema.RenderInline()
+	schemaBytes, _ := json.Marshal(rendered)
+	return string(schemaBytes)
+}
+
 // ValidateParameterSchema will validate a parameter against a raw object, or a blob of json/yaml.
 // It will return a list of validation errors, if any.
 //
@@ -128,7 +150,6 @@ func ValidateParameterSchema(
 		hash := schema.GoLow().Hash()
 		if cached, ok := validationOptions.SchemaCache.Load(hash); ok && cached != nil && cached.CompiledSchema != nil {
 			jsch = cached.CompiledSchema
-			jsonSchema = cached.RenderedJSON
 		}
 	}
 

--- a/parameters/validate_parameter.go
+++ b/parameters/validate_parameter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	"github.com/pb33f/libopenapi/utils"
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"go.yaml.in/yaml/v4"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
@@ -65,10 +66,21 @@ func ValidateSingleParameterSchema(
 		// Store in cache for future requests
 		if o != nil && o.SchemaCache != nil && schema != nil && schema.GoLow() != nil {
 			hash := schema.GoLow().Hash()
+
+			renderCtx := base.NewInlineRenderContextForValidation()
+			renderedInline, _ := schema.RenderInlineWithContext(renderCtx)
+			referenceSchema := string(renderedInline)
+
+			var renderedNode yaml.Node
+			_ = yaml.Unmarshal(renderedInline, &renderedNode)
+
 			o.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
-				Schema:         schema,
-				RenderedJSON:   jsonSchema,
-				CompiledSchema: jsch,
+				Schema:          schema,
+				RenderedInline:  renderedInline,
+				ReferenceSchema: referenceSchema,
+				RenderedJSON:    jsonSchema,
+				CompiledSchema:  jsch,
+				RenderedNode:    &renderedNode,
 			})
 		}
 	}
@@ -184,12 +196,17 @@ func ValidateParameterSchema(
 		// Store in cache for future requests
 		if validationOptions != nil && validationOptions.SchemaCache != nil && schema != nil && schema.GoLow() != nil {
 			hash := schema.GoLow().Hash()
+
+			var renderedNode yaml.Node
+			_ = yaml.Unmarshal(renderedSchema, &renderedNode)
+
 			validationOptions.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
 				Schema:          schema,
 				RenderedInline:  renderedSchema,
 				ReferenceSchema: referenceSchema,
 				RenderedJSON:    jsonSchema,
 				CompiledSchema:  jsch,
+				RenderedNode:    &renderedNode,
 			})
 		}
 	}

--- a/parameters/validate_parameter.go
+++ b/parameters/validate_parameter.go
@@ -125,8 +125,9 @@ func GetRenderedSchema(schema *base.Schema, opts *config.ValidationOptions) stri
 		}
 	}
 
-	// Cache miss - render fresh as YAML
-	rendered, _ := schema.RenderInline()
+	// Cache miss - render fresh as YAML using validation mode
+	renderCtx := base.NewInlineRenderContextForValidation()
+	rendered, _ := schema.RenderInlineWithContext(renderCtx)
 	return string(rendered)
 }
 

--- a/parameters/validate_parameter_test.go
+++ b/parameters/validate_parameter_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/pb33f/libopenapi"
+	lowv3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	lowv3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 
 	"github.com/pb33f/libopenapi-validator/cache"
 	"github.com/pb33f/libopenapi-validator/config"
@@ -836,4 +835,284 @@ func Test_ParameterValidation_CacheConsistency(t *testing.T) {
 			assert.Equal(t, len(errorsWithCache), len(errorsNoCache), "Error count should match for %s", tc.name)
 		})
 	}
+}
+
+// Test_GetRenderedSchema_NilSchema verifies GetRenderedSchema handles nil schema gracefully.
+func Test_GetRenderedSchema_NilSchema(t *testing.T) {
+	opts := config.NewValidationOptions()
+	result := GetRenderedSchema(nil, opts)
+	assert.Empty(t, result, "GetRenderedSchema should return empty string for nil schema")
+}
+
+// Test_GetRenderedSchema_NilOptions verifies GetRenderedSchema works without options.
+func Test_GetRenderedSchema_NilOptions(t *testing.T) {
+	// Parse a document to get a properly initialized schema
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test": {
+				"get": {
+					"parameters": [{
+						"name": "id",
+						"in": "query",
+						"schema": {"type": "string", "minLength": 1}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	// Get the parameter schema
+	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
+	param := pathItem.Get.Parameters[0]
+	schema := param.Schema.Schema()
+
+	// Call with nil options - should still render the schema (returns some representation)
+	result := GetRenderedSchema(schema, nil)
+	assert.NotEmpty(t, result, "GetRenderedSchema should render schema even with nil options")
+}
+
+// Test_GetRenderedSchema_CacheHit verifies GetRenderedSchema uses cached data when available.
+func Test_GetRenderedSchema_CacheHit(t *testing.T) {
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test": {
+				"get": {
+					"parameters": [{
+						"name": "id",
+						"in": "query",
+						"schema": {"type": "integer", "minimum": 1}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	// Get the parameter schema
+	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
+	param := pathItem.Get.Parameters[0]
+	schema := param.Schema.Schema()
+
+	// Create options with cache and pre-populate with known value
+	opts := config.NewValidationOptions()
+	hash := schema.GoLow().Hash()
+	testCachedJSON := []byte(`{"type":"integer","minimum":1,"cached":true}`)
+	opts.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
+		Schema:       schema,
+		RenderedJSON: testCachedJSON,
+	})
+
+	// GetRenderedSchema should return the cached value
+	result := GetRenderedSchema(schema, opts)
+	assert.Equal(t, string(testCachedJSON), result, "GetRenderedSchema should return cached JSON")
+}
+
+// Test_GetRenderedSchema_NilCache verifies GetRenderedSchema works when cache is disabled.
+func Test_GetRenderedSchema_NilCache(t *testing.T) {
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test": {
+				"get": {
+					"parameters": [{
+						"name": "id",
+						"in": "query",
+						"schema": {"type": "boolean"}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	// Get the parameter schema
+	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
+	param := pathItem.Get.Parameters[0]
+	schema := param.Schema.Schema()
+
+	// Create options with cache disabled
+	opts := config.NewValidationOptions(config.WithSchemaCache(nil))
+	require.Nil(t, opts.SchemaCache)
+
+	// GetRenderedSchema should still work by rendering fresh (returns some representation)
+	result := GetRenderedSchema(schema, opts)
+	assert.NotEmpty(t, result, "GetRenderedSchema should render schema even with nil cache")
+}
+
+// Test_GetRenderedSchema_CacheMiss verifies GetRenderedSchema renders fresh when cache entry has empty RenderedJSON.
+// This tests the code path where cache lookup succeeds but RenderedJSON is empty.
+func Test_GetRenderedSchema_CacheMiss(t *testing.T) {
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test": {
+				"get": {
+					"parameters": [{
+						"name": "id",
+						"in": "query",
+						"schema": {"type": "integer"}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	// Get the parameter schema
+	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
+	param := pathItem.Get.Parameters[0]
+	schema := param.Schema.Schema()
+
+	// Create options with cache enabled
+	opts := config.NewValidationOptions()
+	require.NotNil(t, opts.SchemaCache)
+
+	// Store an entry with empty RenderedJSON to simulate cache miss scenario
+	hash := schema.GoLow().Hash()
+	opts.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
+		Schema:       schema,
+		RenderedJSON: nil, // Empty - should trigger fresh rendering
+	})
+
+	// GetRenderedSchema should render fresh since RenderedJSON is empty
+	result := GetRenderedSchema(schema, opts)
+	assert.NotEmpty(t, result, "GetRenderedSchema should render fresh when cached RenderedJSON is empty")
+}
+
+// Test_ValidateSingleParameterSchema_CacheMissCompiledSchema tests the path where cache entry
+// exists but CompiledSchema is nil, forcing recompilation.
+func Test_ValidateSingleParameterSchema_CacheMissCompiledSchema(t *testing.T) {
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test/{id}": {
+				"get": {
+					"parameters": [{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"schema": {"type": "integer", "minimum": 1}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	// Get the parameter schema
+	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test/{id}")
+	param := pathItem.Get.Parameters[0]
+	schema := param.Schema.Schema()
+
+	// Create options with cache enabled
+	opts := config.NewValidationOptions()
+	require.NotNil(t, opts.SchemaCache)
+
+	// Store an entry with nil CompiledSchema to force recompilation
+	hash := schema.GoLow().Hash()
+	opts.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
+		Schema:         schema,
+		CompiledSchema: nil, // nil - should trigger recompilation
+	})
+
+	// Validate should still work by recompiling the schema
+	result := ValidateSingleParameterSchema(
+		schema,
+		int64(5), // valid integer
+		"Path parameter",
+		"The path parameter",
+		"id",
+		helpers.ParameterValidation,
+		helpers.ParameterValidationPath,
+		opts,
+		"/test/{id}",
+		"get",
+	)
+	assert.Empty(t, result, "Validation should pass for valid integer")
+
+	// Now verify the cache was populated with the compiled schema
+	cached, ok := opts.SchemaCache.Load(hash)
+	assert.True(t, ok, "Cache entry should exist")
+	assert.NotNil(t, cached.CompiledSchema, "CompiledSchema should be populated after validation")
+}
+
+// arrayValidationSpec is used to test array parameter validation with the updated function signatures
+var arrayValidationSpec = []byte(`{
+	"openapi": "3.1.0",
+	"info": {"title": "Array Test", "version": "1.0.0"},
+	"paths": {
+		"/test": {
+			"get": {
+				"parameters": [{
+					"name": "ids",
+					"in": "query",
+					"schema": {
+						"type": "array",
+						"items": {"type": "integer", "minimum": 1}
+					}
+				}],
+				"responses": {"200": {"description": "OK"}}
+			}
+		}
+	}
+}`)
+
+// Test_ArrayValidation_ErrorContainsRenderedSchema verifies that array validation errors
+// still contain the rendered schema after the rendering optimization.
+func Test_ArrayValidation_ErrorContainsRenderedSchema(t *testing.T) {
+	doc, err := libopenapi.NewDocument(arrayValidationSpec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	validator := NewParameterValidator(&v3Model.Model)
+
+	// Request with invalid array values (strings instead of integers)
+	req, _ := http.NewRequest("GET", "/test?ids=abc,def", nil)
+
+	success, validationErrors := validator.ValidateQueryParams(req)
+	assert.False(t, success, "Validation should fail for non-integer array values")
+	assert.NotEmpty(t, validationErrors, "Should have validation errors")
+
+	// Verify error message is properly formatted
+	assert.Contains(t, validationErrors[0].Message, "ids", "Error should reference parameter name")
 }

--- a/parameters/validate_parameter_test.go
+++ b/parameters/validate_parameter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
 	lowv3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1260,4 +1261,98 @@ func Test_ReferenceSchema_ConsistentFormat(t *testing.T) {
 	// Both should be plain YAML with the same content
 	assert.Equal(t, refSchema1, refSchema2,
 		"ReferenceSchema should be consistent regardless of error path")
+}
+
+// Test_GetRenderedSchema_ValidationModeConsistency verifies that GetRenderedSchema produces
+// identical output on cache hit vs cache miss for schemas with discriminators. The cache
+// stores schemas rendered with validation mode, so cache misses must also use validation
+// mode for consistency.
+func Test_GetRenderedSchema_ValidationModeConsistency(t *testing.T) {
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test": {
+				"get": {
+					"parameters": [{
+						"name": "pet",
+						"in": "query",
+						"required": true,
+						"schema": {
+							"discriminator": {
+								"propertyName": "petType",
+								"mapping": {
+									"cat": "#/components/schemas/Cat",
+									"dog": "#/components/schemas/Dog"
+								}
+							},
+							"oneOf": [
+								{"$ref": "#/components/schemas/Cat"},
+								{"$ref": "#/components/schemas/Dog"}
+							]
+						}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		},
+		"components": {
+			"schemas": {
+				"Cat": {
+					"type": "object",
+					"properties": {
+						"petType": {"type": "string"},
+						"meow": {"type": "boolean"}
+					},
+					"required": ["petType"]
+				},
+				"Dog": {
+					"type": "object",
+					"properties": {
+						"petType": {"type": "string"},
+						"bark": {"type": "boolean"}
+					},
+					"required": ["petType"]
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	// Get the discriminator schema
+	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
+	schema := pathItem.Get.Parameters[0].Schema.Schema()
+
+	// Get ground truth: what the cache would store (validation mode)
+	renderCtx := base.NewInlineRenderContextForValidation()
+	expectedRendered, err := schema.RenderInlineWithContext(renderCtx)
+	require.NoError(t, err)
+	expected := string(expectedRendered)
+
+	// Test cache miss path
+	optsNoCache := config.NewValidationOptions(config.WithSchemaCache(nil))
+	resultCacheMiss := GetRenderedSchema(schema, optsNoCache)
+
+	assert.Equal(t, expected, resultCacheMiss,
+		"Cache miss should produce same output as validation mode rendering")
+
+	// Test cache hit path
+	optsWithCache := config.NewValidationOptions()
+	hash := schema.GoLow().Hash()
+	optsWithCache.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
+		RenderedInline: expectedRendered,
+	})
+	resultCacheHit := GetRenderedSchema(schema, optsWithCache)
+
+	assert.Equal(t, expected, resultCacheHit,
+		"Cache hit should return the cached validation mode rendering")
+
+	// Test both paths are identical
+	assert.Equal(t, resultCacheHit, resultCacheMiss,
+		"GetRenderedSchema should produce identical output regardless of cache state")
 }

--- a/parameters/validate_parameter_test.go
+++ b/parameters/validate_parameter_test.go
@@ -12,6 +12,7 @@ import (
 
 	lowv3 "github.com/pb33f/libopenapi/datamodel/low/v3"
 
+	"github.com/pb33f/libopenapi-validator/cache"
 	"github.com/pb33f/libopenapi-validator/config"
 	"github.com/pb33f/libopenapi-validator/helpers"
 )
@@ -676,5 +677,163 @@ func BenchmarkValidationWithRegexCache(b *testing.B) {
 		validator.ValidateQueryParams(req)
 		validator.ValidateSecurity(req)
 		validator.ValidatePathParams(req)
+	}
+}
+
+// cacheTestSpec is an OpenAPI spec for testing cache behavior
+var cacheTestSpec = []byte(`{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Cache Test API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/items/{id}": {
+      "get": {
+        "operationId": "getItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}`)
+
+// Test_ParameterValidation_CacheUsage verifies that parameter validation uses the schema cache.
+// This test validates that:
+// 1. Cache is populated after the first validation
+// 2. Subsequent validations reuse the cached compiled schemas
+// 3. Validation still produces correct results when using cached schemas
+func Test_ParameterValidation_CacheUsage(t *testing.T) {
+	doc, err := libopenapi.NewDocument(cacheTestSpec)
+	require.NoError(t, err, "Failed to create document")
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs, "Failed to build v3 model")
+
+	// Create options with cache (default behavior)
+	opts := config.NewValidationOptions()
+	require.NotNil(t, opts.SchemaCache, "Schema cache should be initialized by default")
+
+	validator := NewParameterValidator(&v3Model.Model, config.WithExistingOpts(opts))
+
+	// First request - should populate cache
+	req1, _ := http.NewRequest("GET", "/items/abc123?limit=50", nil)
+	isSuccess1, errors1 := validator.ValidateQueryParams(req1)
+	assert.True(t, isSuccess1, "First validation should succeed")
+	assert.Empty(t, errors1, "First validation should have no errors")
+
+	// Count cached entries (should have at least the limit parameter schema)
+	cacheCount := 0
+	opts.SchemaCache.Range(func(key uint64, value *cache.SchemaCacheEntry) bool {
+		cacheCount++
+		return true
+	})
+	assert.Greater(t, cacheCount, 0, "Cache should have entries after first validation")
+
+	// Second request with different valid value - should use cached schema
+	req2, _ := http.NewRequest("GET", "/items/xyz789?limit=75", nil)
+	isSuccess2, errors2 := validator.ValidateQueryParams(req2)
+	assert.True(t, isSuccess2, "Second validation should succeed")
+	assert.Empty(t, errors2, "Second validation should have no errors")
+
+	// Third request with invalid value - should still use cached schema but fail validation
+	req3, _ := http.NewRequest("GET", "/items/test?limit=999", nil)
+	isSuccess3, errors3 := validator.ValidateQueryParams(req3)
+	assert.False(t, isSuccess3, "Third validation should fail (limit > maximum)")
+	assert.NotEmpty(t, errors3, "Third validation should have errors")
+}
+
+// Test_ParameterValidation_WithoutCache verifies that validation works when cache is disabled.
+func Test_ParameterValidation_WithoutCache(t *testing.T) {
+	doc, err := libopenapi.NewDocument(cacheTestSpec)
+	require.NoError(t, err, "Failed to create document")
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs, "Failed to build v3 model")
+
+	// Create options without cache
+	opts := config.NewValidationOptions(config.WithSchemaCache(nil))
+	require.Nil(t, opts.SchemaCache, "Schema cache should be nil")
+
+	validator := NewParameterValidator(&v3Model.Model, config.WithExistingOpts(opts))
+
+	// Validation should still work without cache
+	req, _ := http.NewRequest("GET", "/items/abc123?limit=50", nil)
+	isSuccess, errors := validator.ValidateQueryParams(req)
+	assert.True(t, isSuccess, "Validation should succeed without cache")
+	assert.Empty(t, errors, "Validation should have no errors")
+
+	// Validation with invalid value should fail
+	req2, _ := http.NewRequest("GET", "/items/abc123?limit=999", nil)
+	isSuccess2, errors2 := validator.ValidateQueryParams(req2)
+	assert.False(t, isSuccess2, "Validation should fail for invalid value")
+	assert.NotEmpty(t, errors2, "Validation should report errors")
+}
+
+// Test_ParameterValidation_CacheConsistency verifies that cached schemas produce
+// the same validation results as freshly compiled schemas.
+func Test_ParameterValidation_CacheConsistency(t *testing.T) {
+	doc, err := libopenapi.NewDocument(cacheTestSpec)
+	require.NoError(t, err, "Failed to create document")
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs, "Failed to build v3 model")
+
+	// Run the same validations with and without cache
+	testCases := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{"valid_limit", "/items/abc?limit=50", true},
+		{"limit_at_max", "/items/abc?limit=100", true},
+		{"limit_at_min", "/items/abc?limit=1", true},
+		{"limit_too_high", "/items/abc?limit=101", false},
+		{"limit_too_low", "/items/abc?limit=0", false},
+	}
+
+	// First run with cache
+	optsWithCache := config.NewValidationOptions()
+	validatorWithCache := NewParameterValidator(&v3Model.Model, config.WithExistingOpts(optsWithCache))
+
+	// Second run without cache
+	optsNoCache := config.NewValidationOptions(config.WithSchemaCache(nil))
+	validatorNoCache := NewParameterValidator(&v3Model.Model, config.WithExistingOpts(optsNoCache))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", tc.url, nil)
+
+			successWithCache, errorsWithCache := validatorWithCache.ValidateQueryParams(req)
+			successNoCache, errorsNoCache := validatorNoCache.ValidateQueryParams(req)
+
+			assert.Equal(t, tc.expected, successWithCache, "Cached validation result mismatch for %s", tc.name)
+			assert.Equal(t, successWithCache, successNoCache, "Cache vs no-cache results should match for %s", tc.name)
+			assert.Equal(t, len(errorsWithCache), len(errorsNoCache), "Error count should match for %s", tc.name)
+		})
 	}
 }

--- a/parameters/validate_parameter_test.go
+++ b/parameters/validate_parameter_test.go
@@ -846,7 +846,6 @@ func Test_GetRenderedSchema_NilSchema(t *testing.T) {
 
 // Test_GetRenderedSchema_NilOptions verifies GetRenderedSchema works without options.
 func Test_GetRenderedSchema_NilOptions(t *testing.T) {
-	// Parse a document to get a properly initialized schema
 	spec := []byte(`{
 		"openapi": "3.1.0",
 		"info": {"title": "Test", "version": "1.0.0"},
@@ -870,14 +869,16 @@ func Test_GetRenderedSchema_NilOptions(t *testing.T) {
 	v3Model, errs := doc.BuildV3Model()
 	require.Nil(t, errs)
 
-	// Get the parameter schema
 	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
-	param := pathItem.Get.Parameters[0]
-	schema := param.Schema.Schema()
+	schema := pathItem.Get.Parameters[0].Schema.Schema()
 
-	// Call with nil options - should still render the schema (returns some representation)
+	// Ground truth
+	rendered, _ := schema.RenderInline()
+	expected := string(rendered)
+
+	// With nil options should match ground truth
 	result := GetRenderedSchema(schema, nil)
-	assert.NotEmpty(t, result, "GetRenderedSchema should render schema even with nil options")
+	assert.Equal(t, expected, result)
 }
 
 // Test_GetRenderedSchema_CacheHit verifies GetRenderedSchema uses cached data when available.
@@ -905,23 +906,24 @@ func Test_GetRenderedSchema_CacheHit(t *testing.T) {
 	v3Model, errs := doc.BuildV3Model()
 	require.Nil(t, errs)
 
-	// Get the parameter schema
 	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
-	param := pathItem.Get.Parameters[0]
-	schema := param.Schema.Schema()
+	schema := pathItem.Get.Parameters[0].Schema.Schema()
 
-	// Create options with cache and pre-populate with known value
+	// Ground truth
+	rendered, _ := schema.RenderInline()
+	expected := string(rendered)
+
+	// Pre-populate cache with RenderedInline
 	opts := config.NewValidationOptions()
 	hash := schema.GoLow().Hash()
-	testCachedJSON := []byte(`{"type":"integer","minimum":1,"cached":true}`)
 	opts.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
-		Schema:       schema,
-		RenderedJSON: testCachedJSON,
+		Schema:         schema,
+		RenderedInline: rendered,
 	})
 
-	// GetRenderedSchema should return the cached value
+	// Cache hit should match ground truth
 	result := GetRenderedSchema(schema, opts)
-	assert.Equal(t, string(testCachedJSON), result, "GetRenderedSchema should return cached JSON")
+	assert.Equal(t, expected, result)
 }
 
 // Test_GetRenderedSchema_NilCache verifies GetRenderedSchema works when cache is disabled.
@@ -949,22 +951,21 @@ func Test_GetRenderedSchema_NilCache(t *testing.T) {
 	v3Model, errs := doc.BuildV3Model()
 	require.Nil(t, errs)
 
-	// Get the parameter schema
 	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
-	param := pathItem.Get.Parameters[0]
-	schema := param.Schema.Schema()
+	schema := pathItem.Get.Parameters[0].Schema.Schema()
 
-	// Create options with cache disabled
+	// Ground truth
+	rendered, _ := schema.RenderInline()
+	expected := string(rendered)
+
+	// With nil cache should match ground truth
 	opts := config.NewValidationOptions(config.WithSchemaCache(nil))
-	require.Nil(t, opts.SchemaCache)
-
-	// GetRenderedSchema should still work by rendering fresh (returns some representation)
 	result := GetRenderedSchema(schema, opts)
-	assert.NotEmpty(t, result, "GetRenderedSchema should render schema even with nil cache")
+	assert.Equal(t, expected, result)
 }
 
-// Test_GetRenderedSchema_CacheMiss verifies GetRenderedSchema renders fresh when cache entry has empty RenderedJSON.
-// This tests the code path where cache lookup succeeds but RenderedJSON is empty.
+// Test_GetRenderedSchema_CacheMiss verifies GetRenderedSchema renders fresh when cache entry has empty RenderedInline.
+// This tests the code path where cache lookup succeeds but RenderedInline is empty.
 func Test_GetRenderedSchema_CacheMiss(t *testing.T) {
 	spec := []byte(`{
 		"openapi": "3.1.0",
@@ -989,25 +990,72 @@ func Test_GetRenderedSchema_CacheMiss(t *testing.T) {
 	v3Model, errs := doc.BuildV3Model()
 	require.Nil(t, errs)
 
-	// Get the parameter schema
 	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
-	param := pathItem.Get.Parameters[0]
-	schema := param.Schema.Schema()
+	schema := pathItem.Get.Parameters[0].Schema.Schema()
 
-	// Create options with cache enabled
+	// Ground truth
+	rendered, _ := schema.RenderInline()
+	expected := string(rendered)
+
+	// Store entry with empty RenderedInline to force cache miss
 	opts := config.NewValidationOptions()
-	require.NotNil(t, opts.SchemaCache)
-
-	// Store an entry with empty RenderedJSON to simulate cache miss scenario
 	hash := schema.GoLow().Hash()
 	opts.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
-		Schema:       schema,
-		RenderedJSON: nil, // Empty - should trigger fresh rendering
+		Schema:         schema,
+		RenderedInline: nil, // Empty - should trigger fresh rendering
 	})
 
-	// GetRenderedSchema should render fresh since RenderedJSON is empty
+	// Cache miss should still match ground truth
 	result := GetRenderedSchema(schema, opts)
-	assert.NotEmpty(t, result, "GetRenderedSchema should render fresh when cached RenderedJSON is empty")
+	assert.Equal(t, expected, result)
+}
+
+// Test_GetRenderedSchema_Deterministic verifies that GetRenderedSchema returns the same
+// output regardless of cache state (cache hit vs cache miss).
+func Test_GetRenderedSchema_Deterministic(t *testing.T) {
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test": {
+				"get": {
+					"parameters": [{
+						"name": "status",
+						"in": "query",
+						"schema": {"type": "string", "enum": ["active", "inactive"]}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
+	schema := pathItem.Get.Parameters[0].Schema.Schema()
+
+	// Ground truth
+	rendered, _ := schema.RenderInline()
+	expected := string(rendered)
+
+	// Cache miss path (no cache)
+	optsNoCache := config.NewValidationOptions(config.WithSchemaCache(nil))
+	resultMiss := GetRenderedSchema(schema, optsNoCache)
+	assert.Equal(t, expected, resultMiss)
+
+	// Cache hit path (pre-populated cache)
+	optsWithCache := config.NewValidationOptions()
+	hash := schema.GoLow().Hash()
+	optsWithCache.SchemaCache.Store(hash, &cache.SchemaCacheEntry{
+		RenderedInline: rendered,
+	})
+	resultHit := GetRenderedSchema(schema, optsWithCache)
+	assert.Equal(t, expected, resultHit)
 }
 
 // Test_ValidateSingleParameterSchema_CacheMissCompiledSchema tests the path where cache entry
@@ -1164,4 +1212,52 @@ func Test_ParameterValidation_CompleteCacheEntry(t *testing.T) {
 	assert.NotEmpty(t, cached.RenderedJSON, "RenderedJSON should be populated")
 	assert.NotNil(t, cached.CompiledSchema, "CompiledSchema should be populated")
 	assert.NotNil(t, cached.RenderedNode, "RenderedNode should be populated")
+}
+
+// Test_ReferenceSchema_ConsistentFormat verifies that ReferenceSchema has the same
+// format whether the error comes from GetRenderedSchema or formatJsonSchemaValidationError.
+func Test_ReferenceSchema_ConsistentFormat(t *testing.T) {
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test": {
+				"get": {
+					"parameters": [{
+						"name": "count",
+						"in": "query",
+						"required": true,
+						"schema": {"type": "integer", "minimum": 1, "maximum": 100}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	validator := NewParameterValidator(&v3Model.Model)
+
+	// Error path 1: Missing required parameter (uses GetRenderedSchema)
+	req1, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	_, errors1 := validator.ValidateQueryParams(req1)
+	require.NotEmpty(t, errors1)
+	require.NotEmpty(t, errors1[0].SchemaValidationErrors)
+	refSchema1 := errors1[0].SchemaValidationErrors[0].ReferenceSchema
+
+	// Error path 2: Value outside range (uses formatJsonSchemaValidationError)
+	req2, _ := http.NewRequest(http.MethodGet, "/test?count=999", nil)
+	_, errors2 := validator.ValidateQueryParams(req2)
+	require.NotEmpty(t, errors2)
+	require.NotEmpty(t, errors2[0].SchemaValidationErrors)
+	refSchema2 := errors2[0].SchemaValidationErrors[0].ReferenceSchema
+
+	// Both should be plain YAML with the same content
+	assert.Equal(t, refSchema1, refSchema2,
+		"ReferenceSchema should be consistent regardless of error path")
 }

--- a/parameters/validate_parameter_test.go
+++ b/parameters/validate_parameter_test.go
@@ -1116,3 +1116,52 @@ func Test_ArrayValidation_ErrorContainsRenderedSchema(t *testing.T) {
 	// Verify error message is properly formatted
 	assert.Contains(t, validationErrors[0].Message, "ids", "Error should reference parameter name")
 }
+
+// Test_ParameterValidation_CompleteCacheEntry verifies that parameter validation
+// writes complete cache entries.
+func Test_ParameterValidation_CompleteCacheEntry(t *testing.T) {
+	spec := []byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {
+			"/test": {
+				"get": {
+					"parameters": [{
+						"name": "id",
+						"in": "query",
+						"schema": {"type": "string", "minLength": 1}
+					}],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`)
+
+	doc, err := libopenapi.NewDocument(spec)
+	require.NoError(t, err)
+
+	v3Model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+
+	opts := config.NewValidationOptions()
+	validator := NewParameterValidator(&v3Model.Model, config.WithExistingOpts(opts))
+
+	req, _ := http.NewRequest("GET", "/test?id=abc", nil)
+	valid, _ := validator.ValidateQueryParams(req)
+	assert.True(t, valid)
+
+	pathItem := v3Model.Model.Paths.PathItems.GetOrZero("/test")
+	schema := pathItem.Get.Parameters[0].Schema.Schema()
+	hash := schema.GoLow().Hash()
+
+	cached, ok := opts.SchemaCache.Load(hash)
+	require.True(t, ok, "Cache entry should exist")
+
+	// Check that all fields of the cache entry are populated
+	assert.NotNil(t, cached.Schema, "Schema should be populated")
+	assert.NotEmpty(t, cached.RenderedInline, "RenderedInline should be populated")
+	assert.NotEmpty(t, cached.ReferenceSchema, "ReferenceSchema should be populated")
+	assert.NotEmpty(t, cached.RenderedJSON, "RenderedJSON should be populated")
+	assert.NotNil(t, cached.CompiledSchema, "CompiledSchema should be populated")
+	assert.NotNil(t, cached.RenderedNode, "RenderedNode should be populated")
+}

--- a/parameters/validation_functions.go
+++ b/parameters/validation_functions.go
@@ -119,12 +119,8 @@ func ValidateQueryArray(
 	var validationErrors []*errors.ValidationError
 	itemsSchema := sch.Items.A.Schema()
 
-	var renderedItemsSchema string
-	if itemsSchema != nil {
-		rendered, _ := itemsSchema.RenderInline()
-		schemaBytes, _ := json.Marshal(rendered)
-		renderedItemsSchema = string(schemaBytes)
-	}
+	// Get rendered items schema for ReferenceSchema field in errors (uses cache if available)
+	renderedItemsSchema := GetRenderedSchema(itemsSchema, validationOptions)
 
 	// check for an exploded bit on the schema.
 	// if it's exploded, then we need to check each item in the array


### PR DESCRIPTION
## Summary

This PR fixes a performance issue where parameter validation (path, query, header, cookie) was not utilizing the schema cache, causing expensive schema re-compilation and re-rendering on every request. Request body validation already used caching, but parameter validation was inadvertently left out.

As shown below, this yields **significant** performance improvements for parameter validation.

Related issue: this problem was already mentioned in recent issue https://github.com/pb33f/libopenapi-validator/issues/227

## Problem

When using `libopenapi-validator` for HTTP request validation, we observed that parameter validation was significantly slower than request body validation.

To isolate and demonstrate this issue, we designed benchmarks with two separate endpoints:
- **POST /users** - validates only a request body (no path parameters)
- **GET /users/{userId}/posts** - validates only parameters (path, query, header)

### Test Specification

```yaml
openapi: "3.1.0"
info:
  title: Cache Performance Test API
  version: "1.0.0"
paths:
  /users:
    post:
      operationId: createUser
      requestBody:
        required: true
        content:
          application/json:
            schema:
              type: object
              required: [name, email]
              properties:
                name:
                  type: string
                  minLength: 1
                  maxLength: 100
                email:
                  type: string
                  format: email
                  maxLength: 256
                age:
                  type: integer
                  minimum: 0
                  maximum: 150
                bio:
                  type: string
                  maxLength: 1000
      responses:
        "201":
          description: Created
  /users/{userId}/posts:
    get:
      operationId: getUserPosts
      parameters:
        - name: userId
          in: path
          required: true
          schema:
            type: string
            minLength: 1
            maxLength: 64
        - name: search
          in: query
          schema:
            type: string
            maxLength: 256
        - name: page
          in: query
          schema:
            type: integer
            minimum: 0
            maximum: 1000
        - name: limit
          in: query
          schema:
            type: integer
            minimum: 1
            maximum: 100
        - name: published
          in: query
          schema:
            type: boolean
        - name: sort_by
          in: query
          schema:
            type: string
            enum: ["created_at", "updated_at", "title"]
        - name: order
          in: query
          schema:
            type: string
            enum: ["asc", "desc"]
        - name: X-Request-ID
          in: header
          schema:
            type: string
            maxLength: 64
      responses:
        "200":
          description: OK
```

### Benchmarks and profiling

Running the benchmark code below on an Apple M2 Max shows that parameter validation is significantly slower than body validation:

| Benchmark | Before (time/allocs) |
|-----------|--------|
| body_only (BASELINE) | 19 µs / 133 allocs |
| path_only | 148 µs / 935 allocs |
| path_and_query | 746 µs / 5,086 allocs |
| path_query_and_header | 790 µs / 5,816 allocs |

Running CPU profiling on parameter validation revealed the following breakdown:

```
~35% - os.Getwd() / syscall.Stat / filepath.Abs
       Called from: jsonschema/v6.(*Compiler).AddResource
       Called from: helpers.NewCompiledSchema
       Called from: parameters.ValidateSingleParameterSchema

~32% - RenderInline() calls for error message preparation
       Called from: parameters/query_parameters.go
       Called from: parameters/path_parameters.go
       Called from: parameters/header_parameters.go
       Called from: parameters/cookie_parameters.go

~11% - GC pressure from high allocation rate

~22% - Actual schema compilation and validation work
```

The `syscall` overhead comes from schema re-compilation on every request. The jsonschema library's `AddResource()` function calls `filepath.Abs()` for non-URL resource names, which triggers an `os.Getwd()` syscall.

<details>
<summary>Benchmark Code</summary>

```go
package validator

import (
	"bytes"
	"net/http"
	"net/http/httptest"
	"testing"

	"github.com/pb33f/libopenapi"
)

// testSpecForCacheBenchmark is an OpenAPI spec designed to isolate:
// - Request body validation (POST /users with body only, no path params)
// - Parameter validation (GET /users/{userId}/posts with path, query, header params)
var testSpecForCacheBenchmark = []byte(`
openapi: "3.1.0"
info:
  title: Cache Performance Test API
  version: "1.0.0"
paths:
  /users:
    post:
      operationId: createUser
      requestBody:
        required: true
        content:
          application/json:
            schema:
              type: object
              required:
                - name
                - email
              properties:
                name:
                  type: string
                  minLength: 1
                  maxLength: 100
                email:
                  type: string
                  format: email
                  maxLength: 256
                age:
                  type: integer
                  minimum: 0
                  maximum: 150
                bio:
                  type: string
                  maxLength: 1000
      responses:
        "201":
          description: Created
  /users/{userId}/posts:
    get:
      operationId: getUserPosts
      parameters:
        - name: userId
          in: path
          required: true
          schema:
            type: string
            minLength: 1
            maxLength: 64
        - name: search
          in: query
          schema:
            type: string
            maxLength: 256
        - name: page
          in: query
          schema:
            type: integer
            minimum: 0
            maximum: 1000
        - name: limit
          in: query
          schema:
            type: integer
            minimum: 1
            maximum: 100
        - name: published
          in: query
          schema:
            type: boolean
        - name: sort_by
          in: query
          schema:
            type: string
            enum: ["created_at", "updated_at", "title"]
        - name: order
          in: query
          schema:
            type: string
            enum: ["asc", "desc"]
        - name: X-Request-ID
          in: header
          schema:
            type: string
            maxLength: 64
      responses:
        "200":
          description: OK
`)

// BenchmarkRequestBodyValidation benchmarks request body validation in isolation.
// Uses POST /users which has a body but NO path parameters.
func BenchmarkRequestBodyValidation(b *testing.B) {
	doc, err := libopenapi.NewDocument(testSpecForCacheBenchmark)
	if err != nil {
		b.Fatalf("failed to create document: %v", err)
	}

	v, errs := NewValidator(doc)
	if len(errs) > 0 {
		b.Fatalf("failed to create validator: %v", errs)
	}

	requestBody := []byte(`{
		"name": "John Doe",
		"email": "john.doe@example.com",
		"age": 30,
		"bio": "Software engineer interested in distributed systems."
	}`)

	b.ReportAllocs()
	b.ResetTimer()

	for b.Loop() {
		req := httptest.NewRequest(http.MethodPost, "/users", bytes.NewReader(requestBody))
		req.Header.Set("Content-Type", "application/json")
		v.ValidateHttpRequest(req)
	}
}

// BenchmarkParameterValidation benchmarks parameter validation in isolation.
// Uses GET /users/{userId}/posts with varying combinations of path, query, and header params.
func BenchmarkParameterValidation(b *testing.B) {
	doc, err := libopenapi.NewDocument(testSpecForCacheBenchmark)
	if err != nil {
		b.Fatalf("failed to create document: %v", err)
	}

	v, errs := NewValidator(doc)
	if len(errs) > 0 {
		b.Fatalf("failed to create validator: %v", errs)
	}

	tests := []struct {
		name      string
		url       string
		addHeader bool
	}{
		{
			name:      "path_only",
			url:       "/users/123/posts",
			addHeader: false,
		},
		{
			name:      "path_and_query",
			url:       "/users/123/posts?search=test&page=2&limit=25&published=true&sort_by=created_at&order=desc",
			addHeader: false,
		},
		{
			name:      "path_query_and_header",
			url:       "/users/123/posts?search=test&page=2&limit=25&published=true&sort_by=created_at&order=desc",
			addHeader: true,
		},
	}

	for _, tc := range tests {
		b.Run(tc.name, func(b *testing.B) {
			b.ReportAllocs()
			b.ResetTimer()

			for b.Loop() {
				req := httptest.NewRequest(http.MethodGet, tc.url, nil)
				if tc.addHeader {
					req.Header.Set("X-Request-ID", "test-request-123")
				}
				v.ValidateHttpRequest(req)
			}
		})
	}
}
```

</details>

### Root Cause Analysis

Slow performance for parameter validation originate from 2 issues:

1. **Schema compilation cache not used**: The parameter validation functions (`ValidateSingleParameterSchema` and `ValidateParameterSchema` in `parameters/validate_parameter.go`) do not check the `SchemaCache` before compiling schemas, despite this cache being warmed up at validator initialization via `warmParameterSchema()`.
2. **Schema rendering for error messages**: Even with compilation caching, `RenderInline()` is being called on every validation to prepare schema JSON for potential error messages. These calls happen regardless of whether validation errors occurred, adding unnecessary overhead.

## Testing Results

Running the benchmarks again on an Apple M2 Max after the fix introduced in this PR shows **significant performance improvements**:

| Benchmark | Before | After | Speedup |
|-----------|--------|-------|---------|
| body_only (BASELINE) | 19 µs / 133 allocs | 19 µs / 133 allocs | — |
| path_only | 148 µs / 935 allocs | 21 µs / 177 allocs | **7x** |
| path_and_query | 746 µs / 5,086 allocs | 34 µs / 357 allocs | **22x** |
| path_query_and_header | 790 µs / 5,816 allocs | 38 µs / 382 allocs | **21x** |

Observations:
- Request body validation was already fast (~19 µs) and remains unchanged
- Before this fix, even validating a single path parameter was **8x slower** than validating an entire JSON body
- After this fix, parameter validation performance is comparable to request body validation