### PR TITLE
fix: avoid unaligned 64-bit atomic panic on 32-bit platforms

### DIFF
--- a/parameters/path_parameters_test.go
+++ b/parameters/path_parameters_test.go
@@ -2249,10 +2249,10 @@ paths:
 }
 
 type regexCacheWatcher struct {
-	inner      *sync.Map
 	missCount  int64
 	hitCount   int64
 	storeCount int64
+	inner      *sync.Map
 }
 
 func (c *regexCacheWatcher) Load(key any) (value any, ok bool) {


### PR DESCRIPTION
Reorder fields in regexCacheWatcher to place int64 counters before
the *sync.Map pointer. On 32-bit architectures (i386, armhf), pointers
are 4 bytes, causing the int64 fields to start at offset 4 -- which
is not 8-byte aligned. Go's sync/atomic.AddInt64 panics when the
target int64 is not 8-byte aligned on 32-bit platforms.

Found during Debian package build (golang-github-pb33f-libopenapi-validator)
on i386 and armhf.