### PR TITLE
fix: reuse request body string across schema validation errors

### DIFF
--- a/requests/reference_object_copy_test.go
+++ b/requests/reference_object_copy_test.go
@@ -1,0 +1,73 @@
+// Copyright 2023-2026 Princess Beef Heavy Industries, LLC / Dave Shanley
+// SPDX-License-Identifier: MIT
+
+package requests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unsafe"
+
+	liberrors "github.com/pb33f/libopenapi-validator/errors"
+	"github.com/pb33f/testify/assert"
+	"github.com/pb33f/testify/require"
+)
+
+func TestReferenceObjectCopiesRequestBodyPerViolation(t *testing.T) {
+	const (
+		violations = 80
+		paddingLen = 256 * 1024
+	)
+
+	body := largeObjectWithTypedFields(paddingLen, violations)
+	schema := parseSchemaFromSpec(t, objectSchemaRequiringStrings(violations), 3.1)
+
+	valid, errs := ValidateRequestSchema(&ValidateRequestSchemaInput{
+		Request: postRequestWithBody(body),
+		Schema:  schema,
+		Version: 3.1,
+	})
+	require.False(t, valid)
+	require.Len(t, errs, 1)
+	require.GreaterOrEqual(t, len(errs[0].SchemaValidationErrors), violations)
+
+	ptrs := uniqueReferenceObjectBackings(errs[0].SchemaValidationErrors)
+	t.Logf("body_bytes=%d schema_violations=%d unique_ReferenceObject_backings=%d",
+		len(body), len(errs[0].SchemaValidationErrors), len(ptrs))
+
+	assert.Equal(t, 1, len(ptrs))
+}
+
+func objectSchemaRequiringStrings(fields int) string {
+	var b strings.Builder
+	b.WriteString("type: object\nproperties:\n  pad:\n    type: string\n")
+	for i := 0; i < fields; i++ {
+		fmt.Fprintf(&b, "  f%d:\n    type: string\n", i)
+	}
+	return b.String()
+}
+
+func largeObjectWithTypedFields(paddingLen, fields int) string {
+	var b strings.Builder
+	b.Grow(paddingLen + fields*16 + 32)
+	b.WriteString(`{"pad":"`)
+	b.WriteString(strings.Repeat("x", paddingLen))
+	b.WriteString(`"`)
+	for i := 0; i < fields; i++ {
+		fmt.Fprintf(&b, `,"f%d":1`, i)
+	}
+	b.WriteString(`}`)
+	return b.String()
+}
+
+func uniqueReferenceObjectBackings(fails []*liberrors.SchemaValidationFailure) map[uintptr]struct{} {
+	seen := make(map[uintptr]struct{}, len(fails))
+	for _, fail := range fails {
+		if fail == nil || fail.ReferenceObject == "" {
+			continue
+		}
+		seen[uintptr(unsafe.Pointer(unsafe.StringData(fail.ReferenceObject)))] = struct{}{}
+	}
+	return seen
+}

--- a/requests/validate_request.go
+++ b/requests/validate_request.go
@@ -206,6 +206,7 @@ func ValidateRequestSchema(input *ValidateRequestSchemaInput) (bool, []*liberror
 			schFlatErrs := helpers.FlattenSchemaOutputErrors(jk.DetailedOutput())
 
 			renderedNode, resourceNodes := schema_validation.DiagnosticLocationNodes(renderedSchema, cachedNode, resourceNodes)
+			var fallbackReferenceObject string
 			for q := range schFlatErrs {
 				er := schFlatErrs[q]
 
@@ -240,7 +241,10 @@ func ValidateRequestSchema(input *ValidateRequestSchemaInput) (bool, []*liberror
 						}
 					}
 					if referenceObject == "" {
-						referenceObject = string(requestBody)
+						if fallbackReferenceObject == "" {
+							fallbackReferenceObject = string(requestBody)
+						}
+						referenceObject = fallbackReferenceObject
 					}
 
 					errMsg := er.Error.Kind.LocalizedString(message.NewPrinter(language.Tag{}))

--- a/responses/validate_response.go
+++ b/responses/validate_response.go
@@ -244,6 +244,7 @@ func ValidateResponseSchema(input *ValidateResponseSchemaInput) (bool, []*liberr
 				_ = yaml.Unmarshal(renderedSchema, renderedNode)
 			}
 
+			var fallbackReferenceObject string
 			for q := range schFlatErrs {
 				er := schFlatErrs[q]
 
@@ -276,7 +277,10 @@ func ValidateResponseSchema(input *ValidateResponseSchemaInput) (bool, []*liberr
 						}
 					}
 					if referenceObject == "" {
-						referenceObject = string(responseBody)
+						if fallbackReferenceObject == "" {
+							fallbackReferenceObject = string(responseBody)
+						}
+						referenceObject = fallbackReferenceObject
 					}
 
 					violation := &liberrors.SchemaValidationFailure{

--- a/schema_validation/validate_schema.go
+++ b/schema_validation/validate_schema.go
@@ -258,6 +258,8 @@ func extractBasicErrors(schFlatErrs []jsonschema.OutputUnit,
 	propertyInfo := extractPropertyNameFromError(jk)
 
 	rootNode, resourceNodes := DiagnosticLocationNodes(renderedSchema, renderedNode, resourceNodes)
+	var fallbackReferenceObject string
+	referenceSchema := string(renderedSchema)
 
 	for q := range schFlatErrs {
 		er := schFlatErrs[q]
@@ -292,7 +294,10 @@ func extractBasicErrors(schFlatErrs []jsonschema.OutputUnit,
 				}
 			}
 			if referenceObject == "" {
-				referenceObject = string(payload)
+				if fallbackReferenceObject == "" {
+					fallbackReferenceObject = string(payload)
+				}
+				referenceObject = fallbackReferenceObject
 			}
 
 			violation := &liberrors.SchemaValidationFailure{
@@ -301,7 +306,7 @@ func extractBasicErrors(schFlatErrs []jsonschema.OutputUnit,
 				FieldPath:               helpers.ExtractJSONPathFromStringLocation(er.InstanceLocation),
 				InstancePath:            helpers.ConvertStringLocationToPathSegments(er.InstanceLocation),
 				KeywordLocation:         er.KeywordLocation,
-				ReferenceSchema:         string(renderedSchema),
+				ReferenceSchema:         referenceSchema,
 				ReferenceObject:         referenceObject,
 				OriginalJsonSchemaError: jk,
 			}


### PR DESCRIPTION
### Problem

When a payload fails schema validation, each flattened violation builds a `SchemaValidationFailure` and, for typical object bodies, fills `ReferenceObject` with:

```go
referenceObject = string(requestBody)
```

In Go, `string([]byte)` always copies. The same fallback exists in:

- `requests/validate_request.go`
- `responses/validate_response.go`
- `schema_validation/validate_schema.go` (`string(payload)` and `string(renderedSchema)`)

The `/^(\d+)/` slice-index branch almost never runs for object bodies, so an `8 MiB` body with `384` field errors copies the body **384 times** (~`3 GiB` extra per request).

### Fix

Cache the fallback conversion once per validation pass and reuse it for every violation. `extractBasicErrors` also converts `renderedSchema` once. Strings are immutable, so sharing the backing array does not change the public contract.

### Testing

- Existing `go test ./...` passes.
- Added `TestReferenceObjectCopiesRequestBodyPerViolation`: 80 type mismatches on a ~256 KiB object. Before the fix there are 80 distinct `ReferenceObject` backings; after, there is 1.

Local `ValidateSchemaBytes` benchmark, average of 5 independent runs (schema warmed first):

| Scenario | Current alloc | Fixed alloc | Current | Fixed |
|---|---:|---:|---:|---:|
| 1 MiB, 10 invalid fields | 12.22 MiB | 3.12 MiB | 5.3 ms | 4.6 ms |
| 1 MiB, 100 invalid fields | 103.12 MiB | 3.63 MiB | 8.1 ms | 4.0 ms |
| 5 MiB, 100 invalid fields | 511.13 MiB | 15.59 MiB | 26.3 ms | 14.6 ms |
| 8 MiB, 384 invalid fields | 3.02 GiB | 26.14 MiB | 96.5 ms | 25.2 ms |

Worst case matches `384 × 8 MiB ≈ 3 GiB`. After the cache it is one copy plus parse/error overhead.