### PR TITLE
fix: compare MediaType with wildcards

### DIFF
--- a/responses/validate_body.go
+++ b/responses/validate_body.go
@@ -80,7 +80,7 @@ func (v *responseBodyValidator) ValidateResponseBodyWithPathItem(request *http.R
 	if foundResponse != nil {
 		if v.options.ValidateResponseBody && foundResponse.Content != nil { // only validate if we have content types.
 			// check content type has been defined in the contract
-			if mediaType, ok := foundResponse.Content.Get(mediaTypeSting); ok {
+			if mediaType, ok := v.extractContentType(mediaTypeSting, foundResponse); ok {
 				validationErrors = append(validationErrors,
 					v.checkResponseSchema(request, response, contentType, mediaType, operation)...)
 			} else {
@@ -98,7 +98,7 @@ func (v *responseBodyValidator) ValidateResponseBodyWithPathItem(request *http.R
 			// check content type has been defined in the contract
 			if !v.options.ValidateResponseBody {
 				foundResponse = operation.Responses.Default
-			} else if mediaType, ok := operation.Responses.Default.Content.Get(mediaTypeSting); ok {
+			} else if mediaType, ok := v.extractContentType(mediaTypeSting, operation.Responses.Default); ok {
 				foundResponse = operation.Responses.Default
 				validationErrors = append(validationErrors,
 					v.checkResponseSchema(request, response, contentType, mediaType, operation)...)
@@ -238,4 +238,22 @@ func (v *responseBodyValidator) checkResponseSchema(
 	}
 
 	return validationErrors
+}
+
+func (v *responseBodyValidator) extractContentType(contentType string, response *v3.Response) (*v3.MediaType, bool) {
+	mediaType, ok := response.Content.Get(contentType)
+	if ok {
+		return mediaType, true
+	}
+	ctMediaRange := strings.SplitN(contentType, "/", 2)
+	for contentPair := response.Content.First(); contentPair != nil; contentPair = contentPair.Next() {
+		s := contentPair.Key()
+		mediaTypeValue := contentPair.Value()
+		opMediaRange := strings.SplitN(s, "/", 2)
+		if (opMediaRange[0] == "*" || opMediaRange[0] == ctMediaRange[0]) &&
+			(opMediaRange[1] == "*" || opMediaRange[1] == ctMediaRange[1]) {
+			return mediaTypeValue, true
+		}
+	}
+	return nil, false
 }

--- a/responses/validate_body_test.go
+++ b/responses/validate_body_test.go
@@ -945,6 +945,153 @@ paths:
 	assert.Len(t, errors, 0)
 }
 
+func TestValidateBody_ValidBasicSchema_WithContentTypeWildcards(t *testing.T) {
+	tb := newvalidateResponseTestBed(
+		t,
+		[]byte(`openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      responses:
+        '200':
+          content:
+            "*/*":
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  patties:
+                    type: integer
+                  vegetarian:
+                    type: boolean`,
+		),
+	)
+
+	req, res := tb.makeRequestWithReponse(
+		t,
+		http.MethodPost,
+		"/burgers/createBurger",
+		func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, err := json.Marshal(map[string]interface{}{
+				"name":       "Big Mac",
+				"patties":    2,
+				"vegetarian": false,
+			})
+
+			require.NoError(t, err, "failed to marshal body")
+
+			w.Header().Set(helpers.ContentTypeHeader, helpers.JSONContentType)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bodyBytes)
+		},
+	)
+
+	// validate!
+	valid, errors := tb.responseBodyValidator.ValidateResponseBody(req, res)
+
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
+}
+
+func TestValidateBody_ValidBasicSchema_WithContentTypeWildcardEnd(t *testing.T) {
+	tb := newvalidateResponseTestBed(
+		t,
+		[]byte(`openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      responses:
+        '200':
+          content:
+            "application/*":
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  patties:
+                    type: integer
+                  vegetarian:
+                    type: boolean`,
+		),
+	)
+
+	req, res := tb.makeRequestWithReponse(
+		t,
+		http.MethodPost,
+		"/burgers/createBurger",
+		func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, err := json.Marshal(map[string]interface{}{
+				"name":       "Big Mac",
+				"patties":    2,
+				"vegetarian": false,
+			})
+
+			require.NoError(t, err, "failed to marshal body")
+
+			w.Header().Set(helpers.ContentTypeHeader, helpers.JSONContentType)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bodyBytes)
+		},
+	)
+
+	// validate!
+	valid, errors := tb.responseBodyValidator.ValidateResponseBody(req, res)
+
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
+}
+
+func TestValidateBody_ValidBasicSchema_WithContentTypeWildcardStart(t *testing.T) {
+	tb := newvalidateResponseTestBed(
+		t,
+		[]byte(`openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      responses:
+        '200':
+          content:
+            "*/json":
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  patties:
+                    type: integer
+                  vegetarian:
+                    type: boolean`,
+		),
+	)
+
+	req, res := tb.makeRequestWithReponse(
+		t,
+		http.MethodPost,
+		"/burgers/createBurger",
+		func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, err := json.Marshal(map[string]interface{}{
+				"name":       "Big Mac",
+				"patties":    2,
+				"vegetarian": false,
+			})
+
+			require.NoError(t, err, "failed to marshal body")
+
+			w.Header().Set(helpers.ContentTypeHeader, helpers.JSONContentType)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bodyBytes)
+		},
+	)
+
+	// validate!
+	valid, errors := tb.responseBodyValidator.ValidateResponseBody(req, res)
+
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
+}
+
 func TestValidateBody_ValidBasicSchemaUsingDefault(t *testing.T) {
 	tb := newvalidateResponseTestBed(
 		t,
@@ -956,6 +1103,153 @@ paths:
         default:
           content:
             application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  patties:
+                    type: integer
+                  vegetarian:
+                    type: boolean`,
+		),
+	)
+
+	req, res := tb.makeRequestWithReponse(
+		t,
+		http.MethodPost,
+		"/burgers/createBurger",
+		func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, err := json.Marshal(map[string]interface{}{
+				"name":       "Big Mac",
+				"patties":    2,
+				"vegetarian": false,
+			})
+
+			require.NoError(t, err, "failed to marshal body")
+
+			w.Header().Set(helpers.ContentTypeHeader, helpers.JSONContentType)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bodyBytes)
+		},
+	)
+
+	// validate!
+	valid, errors := tb.responseBodyValidator.ValidateResponseBody(req, res)
+
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
+}
+
+func TestValidateBody_ValidBasicSchemaUsingDefault_WithContentTypeWildcards(t *testing.T) {
+	tb := newvalidateResponseTestBed(
+		t,
+		[]byte(`openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      responses:
+        default:
+          content:
+            "*/*":
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  patties:
+                    type: integer
+                  vegetarian:
+                    type: boolean`,
+		),
+	)
+
+	req, res := tb.makeRequestWithReponse(
+		t,
+		http.MethodPost,
+		"/burgers/createBurger",
+		func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, err := json.Marshal(map[string]interface{}{
+				"name":       "Big Mac",
+				"patties":    2,
+				"vegetarian": false,
+			})
+
+			require.NoError(t, err, "failed to marshal body")
+
+			w.Header().Set(helpers.ContentTypeHeader, helpers.JSONContentType)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bodyBytes)
+		},
+	)
+
+	// validate!
+	valid, errors := tb.responseBodyValidator.ValidateResponseBody(req, res)
+
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
+}
+
+func TestValidateBody_ValidBasicSchemaUsingDefault_WithContentTypeWildcardEnd(t *testing.T) {
+	tb := newvalidateResponseTestBed(
+		t,
+		[]byte(`openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      responses:
+        default:
+          content:
+            "application/*":
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  patties:
+                    type: integer
+                  vegetarian:
+                    type: boolean`,
+		),
+	)
+
+	req, res := tb.makeRequestWithReponse(
+		t,
+		http.MethodPost,
+		"/burgers/createBurger",
+		func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, err := json.Marshal(map[string]interface{}{
+				"name":       "Big Mac",
+				"patties":    2,
+				"vegetarian": false,
+			})
+
+			require.NoError(t, err, "failed to marshal body")
+
+			w.Header().Set(helpers.ContentTypeHeader, helpers.JSONContentType)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bodyBytes)
+		},
+	)
+
+	// validate!
+	valid, errors := tb.responseBodyValidator.ValidateResponseBody(req, res)
+
+	assert.True(t, valid)
+	assert.Len(t, errors, 0)
+}
+
+func TestValidateBody_ValidBasicSchemaUsingDefault_WithContentTypeWildcardStart(t *testing.T) {
+	tb := newvalidateResponseTestBed(
+		t,
+		[]byte(`openapi: 3.1.0
+paths:
+  /burgers/createBurger:
+    post:
+      responses:
+        default:
+          content:
+            "*/json":
               schema:
                 type: object
                 properties:


### PR DESCRIPTION
When checking for a matching response in OpenAPI with ContentType from responss body, match OpenAPI spec wildcards

New "extractContentType" function copied and adapted from the same function in requests/validate_body.go

Closes #316 